### PR TITLE
Cleanup and re-enable tests in pf algo *again*

### DIFF
--- a/run_hls.tcl
+++ b/run_hls.tcl
@@ -6,7 +6,7 @@
 
 # open the project, don't forget to reset
 open_project -reset proj0
-set_top simple_pflow_parallel_hwopt
+set_top medium_pflow_parallel_hwopt
 add_files src/simple_pflow.cpp
 add_files -tb simple_pflow_test.cpp 
 add_files -tb simple_pflow_ref.cpp

--- a/simple_pflow_test.cpp
+++ b/simple_pflow_test.cpp
@@ -74,7 +74,6 @@ int main() {
 
 
 // ---------------- COMPARE WITH EXPECTED ----------------
-/*
 		int errors = 0; int ntot = 0, nch = 0, nneu = 0;
 		/*// == LINKING COMPARISON ===
 		for (int i = 0; i < NTRACK; ++i) { for (int j = 0; j < NCALO; ++j) {
@@ -179,7 +178,6 @@ int main() {
 		} else {
 			printf("Passed test %d (%d, %d, %d)\n", test, ntot, nch, nneu);
 		}
-	*/
 
 	}
 	return 0;

--- a/simple_vtx_ref.cpp
+++ b/simple_vtx_ref.cpp
@@ -5,6 +5,7 @@
 #ifndef __SYNTHESIS__
 #include <cstdio>
 #endif
+#define Z0_SCALE 20.
 
 void simple_vtx_ref(TkObj track[NALLTRACK], VtxObj *outvtx) { 
   //Fill sum Et and count binned in dZ

--- a/simple_vtx_test.cpp
+++ b/simple_vtx_test.cpp
@@ -3,6 +3,9 @@
 
 #define NTEST 50
 #define NPV   15
+#define Z0_SCALE 20.
+#define PT_SCALE 4.0
+#define ETAPHI_SCALE (4*180/M_PI)
 
 int main() {
   srand(73); // 73 is also a prime number just to be different than Gio ;p

--- a/src/data.h
+++ b/src/data.h
@@ -11,19 +11,21 @@ typedef ap_int<10> z0_t;  // 40cm / 0.1
 		
 enum PID { PID_Charged=0, PID_Neutral=1 };
 
+// VERTEXING
 #define NVTXBINS  15
 #define NPOW 6
 #define NALLTRACK 1 << NPOW
 #define NSECTOR 1
 #define VTXPTMAX  200
+
+// PF
 #define NTRACK 8
 #define NCALO 12
 #define NSELCALO 15
 
+// PUPPI & CHS
 #define NPVTRACK 7
-#define PT_SCALE 4.0
-#define ETAPHI_SCALE (4*180/M_PI)
-#define Z0_SCALE 20.
+
 
 struct CaloObj {
 	pt_t hwPt;


### PR DESCRIPTION
note: both before & after this PR, vertexing part does not compile, complaining with
````
../../../../src/simple_vtx.cpp: In function ‘void fillVtx(TkObj, ap_int<5>*, pt_t*)’:
../../../../src/simple_vtx.cpp:38:34: error: ‘z0bin’ was not declared in this scope
../../../../src/simple_vtx.cpp: In function ‘void simple_vtx_hwopt(TkObj*, VtxObj*)’:
../../../../src/simple_vtx.cpp:92:40: error: ‘convertZ0’ was not declared in this scope
````
