### PR TITLE
bulk of PFAlgo3

### DIFF
--- a/DiscretePFInputs_IO.h
+++ b/DiscretePFInputs_IO.h
@@ -84,7 +84,7 @@ class DiscretePFInputs {
 			return true;
 		}
 		bool nextRegion(HadCaloObj calo[NCALO], EmCaloObj emcalo[NEMCALO], TkObj track[NTRACK], z0_t & hwZPV) {
-			if (!nextRegion(calo, track, hwZPV)) return false;
+			if (!nextRegion()) return false;
 		    	const Region &r = event_.regions[iregion_];
 			readHadCalo(calo);
 			readEmCalo(emcalo);
@@ -137,6 +137,7 @@ class DiscretePFInputs {
 				calo[i].hwEmPt = r.calo[i].hwEmPt;
 				calo[i].hwEta = r.calo[i].hwEta;
 				calo[i].hwPhi = r.calo[i].hwPhi;
+				calo[i].hwIsEM = r.calo[i].isEM;
 			}
 		}
 		void readEmCalo(EmCaloObj calo[NEMCALO]) {

--- a/run_hls_pfalgo3.tcl
+++ b/run_hls_pfalgo3.tcl
@@ -1,0 +1,34 @@
+############################################################
+## This file is generated automatically by Vivado HLS.
+## Please DO NOT edit it.
+## Copyright (C) 1986-2016 Xilinx, Inc. All Rights Reserved.
+############################################################
+
+# open the project, don't forget to reset
+open_project -reset proj2
+#set_top tk2calo_algo
+set_top tk2em_step1
+add_files src/simple_pfalgo3.cpp
+add_files -tb simple_pfalgo3_test.cpp 
+add_files -tb simple_pfalgo3_ref.cpp
+add_files -tb DiscretePFInputs.h -cflags "-std=c++0x"
+add_files -tb DiscretePFInputs_IO.h -cflags "-std=c++0x"
+add_files -tb data/regions_TTbar_PU140.dump
+
+# reset the solution
+open_solution -reset "solution1"
+#set_part {xcku9p-ffve900-2-i-EVAL}
+#set_part {xc7vx690tffg1927-2}
+#set_part {xcku5p-sfvb784-3-e}
+set_part {xcku115-flvf1924-2-i}
+create_clock -period 5 -name default
+#source "./nb1/solution1/directives.tcl"
+
+# do stuff
+csim_design
+#csynth_design
+#cosim_design -trace_level all
+#export_design -format ip_catalog
+
+# exit Vivado HLS
+exit

--- a/run_hls_pfalgo3.tcl
+++ b/run_hls_pfalgo3.tcl
@@ -6,10 +6,13 @@
 
 # open the project, don't forget to reset
 open_project -reset proj2
-#set_top tk2calo_algo
-set_top tk2em_step1
+#set_top pfalgo3_calo
+#set_top pfalgo3_em
+set_top pfalgo3_full
 add_files src/simple_pfalgo3.cpp
-add_files -tb simple_pfalgo3_test.cpp 
+#add_files -tb simple_pfalgo3_test.cpp  -cflags "-DTESTCALO"
+#add_files -tb simple_pfalgo3_test.cpp  -cflags "-DTESTEM"
+add_files -tb simple_pfalgo3_test.cpp  -cflags "-DTESTFULL"
 add_files -tb simple_pfalgo3_ref.cpp
 add_files -tb DiscretePFInputs.h -cflags "-std=c++0x"
 add_files -tb DiscretePFInputs_IO.h -cflags "-std=c++0x"
@@ -25,8 +28,8 @@ create_clock -period 5 -name default
 #source "./nb1/solution1/directives.tcl"
 
 # do stuff
-csim_design
-#csynth_design
+#csim_design
+csynth_design
 #cosim_design -trace_level all
 #export_design -format ip_catalog
 

--- a/simple_pfalgo3_ref.cpp
+++ b/simple_pfalgo3_ref.cpp
@@ -1,0 +1,199 @@
+#include "src/data.h"
+#include "src/simple_pfalgo3.h"
+#include <cmath>
+#include <algorithm>
+
+template <typename T> int sqr(const T & t) { return t*t; }
+
+template<int NCAL, int DR2MAX, bool doPtMin, typename CO_t>
+int best_match_ref(CO_t calo[NCAL], const TkObj & track) {
+    pt_t caloPtMin = track.hwPt - 2*(track.hwPtErr);
+    int  drmin = DR2MAX, ibest = -1;
+    for (int ic = 0; ic < NCAL; ++ic) {
+            if (doPtMin && calo[ic].hwPt <= caloPtMin) continue;
+            int dr = dr2_int(track.hwEta, track.hwPhi, calo[ic].hwEta, calo[ic].hwPhi);
+            if (dr < drmin) { drmin = dr; ibest = ic; }
+    }
+    return ibest;
+}
+template<int NCAL, int DR2MAX>
+int best_match_ref(HadCaloObj calo[NCAL], const EmCaloObj & em) {
+    pt_t emPtMin = em.hwPt >> 1;
+    int  drmin = DR2MAX, ibest = -1;
+    for (int ic = 0; ic < NCAL; ++ic) {
+            if (calo[ic].hwEmPt < emPtMin) continue;
+            int dr = dr2_int(em.hwEta, em.hwPhi, calo[ic].hwEta, calo[ic].hwPhi);
+            if (dr < drmin) { drmin = dr; ibest = ic; }
+    }
+    return ibest;
+}
+
+template<int NCAL, int DR2MAX, bool doPtMin, typename CO_t>
+void link_ref(CO_t calo[NCAL], TkObj track[NTRACK], ap_uint<NCAL> calo_track_link_bit[NTRACK]) {
+    for (int it = 0; it < NTRACK; ++it) {
+        int ibest = best_match_ref<NCALO,DR2MAX,doPtMin,CO_t>(calo, track[it]);
+        calo_track_link_bit[it] = 0;
+        if (ibest != -1) calo_track_link_bit[it][ibest] = 1;
+    }
+}
+
+template<typename T, int NIn, int NOut>
+void ptsort_ref(T in[NIn], T out[NOut]) {
+    for (int iout = 0; iout < NOut; ++iout) {
+        out[iout].hwPt = 0;
+    }
+    int nout = 0;
+    for (int it = 0; it < NIn; ++it) {
+        for (int iout = 0; iout < NOut; ++iout) {
+            if (in[it].hwPt >= out[iout].hwPt) {
+                for (int i2 = NOut-1; i2 > iout; --i2) {
+                    out[i2] = out[i2-1];
+                }
+                out[iout] = in[it];
+                break;
+            }
+        }
+    }
+}
+
+
+void pfalgo3_ref(HadCaloObj calo[NCALO], TkObj track[NTRACK], PFChargedObj outch[NTRACK], PFNeutralObj outne[NCALO]) {
+    // constants
+    const pt_t     TKPT_MAX = 80; // 20 * PT_SCALE;
+    const int      DR2MAX   = 2101;
+
+    // initialize sum track pt
+    pt_t calo_sumtk[NCALO], calo_subpt[NCALO];
+    int  calo_sumtkErr2[NCALO];
+    for (int ic = 0; ic < NCALO; ++ic) { calo_sumtk[ic] = 0;  calo_sumtkErr2[ic] = 0;}
+
+    // initialize good track bit
+    bool track_good[NTRACK];
+    for (int it = 0; it < NTRACK; ++it) { track_good[it] = (track[it].hwPt < TKPT_MAX); }
+
+    // initialize output
+    for (int ipf = 0; ipf < NTRACK; ++ipf) { outch[ipf].hwPt = 0; }
+    for (int ipf = 0; ipf < NCALO; ++ipf) { outne[ipf].hwPt = 0; }
+
+    // for each track, find the closest calo
+    for (int it = 0; it < NTRACK; ++it) {
+        if (track[it].hwPt > 0) {
+            int  ibest = best_match_ref<NCALO,DR2MAX,true,HadCaloObj>(calo, track[it]);
+            if (ibest != -1) {
+                track_good[it] = 1;
+                calo_sumtk[ibest]    += track[it].hwPt;
+                calo_sumtkErr2[ibest] += sqr(track[it].hwPtErr);
+            }
+        }
+    }
+
+    for (int ic = 0; ic < NCALO; ++ic) {
+        if (calo_sumtk[ic] > 0) {
+            pt_t ptdiff = calo[ic].hwPt - calo_sumtk[ic];
+            if (ptdiff > 0 && ptdiff*ptdiff > 4*calo_sumtkErr2[ic]) {
+                calo_subpt[ic] = ptdiff;
+            } else {
+                calo_subpt[ic] = 0;
+            }
+        } else {
+            calo_subpt[ic] = calo[ic].hwPt;
+        }
+    }
+
+    // copy out charged hadrons
+    for (int it = 0; it < NTRACK; ++it) {
+        if (track_good[it]) {
+            outch[it].hwPt = track[it].hwPt;
+            outch[it].hwEta = track[it].hwEta;
+            outch[it].hwPhi = track[it].hwPhi;
+            outch[it].hwZ0 = track[it].hwZ0;
+            outch[it].hwId  = PID_Charged;
+        }
+    }
+
+    // copy out neutral hadrons
+    PFNeutralObj outne_all[NCALO];
+    for (int ic = 0; ic < NCALO; ++ic) {
+        if (calo_subpt[ic] > 0) {
+            outne_all[ic].hwPt  = calo_subpt[ic];
+            outne_all[ic].hwEta = calo[ic].hwEta;
+            outne_all[ic].hwPhi = calo[ic].hwPhi;
+            outne_all[ic].hwId  = PID_Neutral;
+        }
+    }
+
+    ptsort_ref<PFNeutralObj,NCALO,NSELCALO>(outne_all, outne);
+}
+
+void tk2em_step1_ref(EmCaloObj emcalo[NEMCALO], HadCaloObj hadcalo[NCALO], TkObj track[NTRACK], bool isEle[NTRACK], PFNeutralObj outpho[NPHOTON]) {
+    // constants
+    const int DR2MAX_TE = 84;
+    const int DR2MAX_EH = 525;
+
+    // initialize sum track pt
+    pt_t calo_sumtk[NEMCALO];
+    for (int ic = 0; ic < NEMCALO; ++ic) {  calo_sumtk[NEMCALO] = 0; }
+    int tk2em[NTRACK]; 
+    bool isEM[NEMCALO];
+    // for each track, find the closest calo
+    for (int it = 0; it < NTRACK; ++it) {
+        if (track[it].hwPt > 0) {
+            tk2em[it] = best_match_ref<NEMCALO,DR2MAX_TE,false,EmCaloObj>(emcalo, track[it]);
+            if (tk2em[it] != -1) {
+                calo_sumtk[tk2em[it]] += track[it].hwPt;
+            }
+        } else {
+        	tk2em[it] = -1;
+        }
+    }
+
+    for (int ic = 0; ic < NEMCALO; ++ic) {
+        pt_t photonPt;
+        if (calo_sumtk[ic] > 0) {
+            pt_t ptdiff = emcalo[ic].hwPt - calo_sumtk[ic];
+            if (ptdiff*ptdiff <= 4*sqr(emcalo[ic].hwPtErr)) {
+                // electron
+                photonPt = 0; 
+                isEM[ic] = true;
+            } else if (ptdiff > 0) {
+                // electron + photon
+                photonPt = ptdiff; 
+                isEM[ic] = true;
+            } else {
+                // pion
+                photonPt = 0;
+                isEM[ic] = false;
+            }
+        } else {
+            // photon
+            isEM[ic] = true;
+            photonPt = emcalo[ic].hwPt;
+        }
+        outpho[ic].hwPt  = photonPt;
+        outpho[ic].hwEta = photonPt ? emcalo[ic].hwEta : etaphi_t(0);
+        outpho[ic].hwPhi = photonPt ? emcalo[ic].hwPhi : etaphi_t(0);
+        outpho[ic].hwId  = photonPt ? PID_Photon : particleid_t(0);
+    }
+
+    for (int it = 0; it < NTRACK; ++it) {
+        isEle[it] = (tk2em[it] != -1) && isEM[tk2em[it]];
+    }
+
+    int em2calo[NEMCALO];
+    for (int ic = 0; ic < NEMCALO; ++ic) {
+        em2calo[ic] = best_match_ref<NCALO,DR2MAX_EH>(hadcalo, emcalo[ic]);
+    }
+    
+    for (int ih = 0; ih < NCALO; ++ih) {
+        pt_t sub = 0;
+        for (int ic = 0; ic < NEMCALO; ++ic) {
+            if (isEM[ic] && (em2calo[ic] == ih)) {
+                sub += emcalo[ic];
+            }
+        }
+        
+    }
+    
+
+}
+

--- a/simple_pfalgo3_test.cpp
+++ b/simple_pfalgo3_test.cpp
@@ -1,0 +1,128 @@
+#include <cstdio>
+#include "src/simple_pfalgo3.h"
+#include "random_inputs.h"
+#include "DiscretePFInputs_IO.h"
+
+#define NTEST 500
+
+bool pf_equals(const PFChargedObj &out_ref, const PFChargedObj &out, const char *what, int idx) {
+    bool ret;
+    if (out_ref.hwPt == 0) {
+        ret = (out.hwPt == 0);
+    } else {
+        ret = (out_ref.hwPt == out.hwPt && out_ref.hwEta == out.hwEta && out_ref.hwPhi == out.hwPhi && out_ref.hwId  == out.hwId && out_ref.hwZ0  == out.hwZ0);
+    }
+    if  (!ret) {
+        printf("Mismatch at %s[%3d], hwPt % 7d % 7d   hwEta %+7d %+7d   hwPhi %+7d %+7d   hwId %1d %1d      hwZ0 %+7d %+7d   \n", what, idx,
+                int(out_ref.hwPt), int(out.hwPt),
+                int(out_ref.hwEta), int(out.hwEta),
+                int(out_ref.hwPhi), int(out.hwPhi),
+                int(out_ref.hwId), int(out.hwId),
+                int(out_ref.hwZ0), int(out.hwZ0));
+    }
+    return ret;
+}
+bool pf_equals(const PFNeutralObj &out_ref, const PFNeutralObj &out, const char *what, int idx) {
+    bool ret;
+    if (out_ref.hwPt == 0) {
+        ret = (out.hwPt == 0);
+    } else {
+        ret = (out_ref.hwPt == out.hwPt && out_ref.hwEta == out.hwEta && out_ref.hwPhi == out.hwPhi && out_ref.hwId  == out.hwId);
+    }
+    if  (!ret) {
+        printf("Mismatch at %s[%3d], hwPt % 7d % 7d   hwEta %+7d %+7d   hwPhi %+7d %+7d   hwId %1d %1d \n", what, idx,
+                int(out_ref.hwPt), int(out.hwPt),
+                int(out_ref.hwEta), int(out.hwEta),
+                int(out_ref.hwPhi), int(out.hwPhi),
+                int(out_ref.hwId), int(out.hwId));
+    }
+    return ret;
+}
+int main() {
+
+    //RandomPFInputs inputs(37); // 37 is a good random number
+    DiscretePFInputs inputs("regions_TTbar_PU140.dump");
+    
+    HadCaloObj calo[NCALO]; EmCaloObj emcalo[NEMCALO]; TkObj track[NTRACK]; z0_t hwZPV;
+    PFChargedObj outch[NTRACK], outch_ref[NTRACK];
+    PFNeutralObj outpho[NPHOTON], outpho_ref[NPHOTON];
+    PFNeutralObj outne[NSELCALO], outne_ref[NSELCALO];
+
+    for (int test = 1; test <= NTEST; ++test) {
+        for (int i = 0; i < NTRACK; ++i) {
+            track[i].hwPt = 0; track[i].hwPtErr = 0; track[i].hwEta = 0; track[i].hwPhi = 0; track[i].hwZ0 = 0;
+        }
+        for (int i = 0; i < NCALO; ++i) {
+            calo[i].hwPt = 0; calo[i].hwEmPt = 0; calo[i].hwEta = 0; calo[i].hwPhi = 0;
+        }
+        for (int i = 0; i < NEMCALO; ++i) {
+            emcalo[i].hwPt = 0;emcalo[i].hwPtErr = 0;  emcalo[i].hwEta = 0; emcalo[i].hwPhi = 0;
+        }
+
+
+        if (!inputs.nextRegion(calo, emcalo, track, hwZPV)) break;
+
+        //pfalgo3_ref(calo, track, outch_ref, outne_ref);
+        //tk2calo_algo(calo, track, outch, outne);
+        bool isEle[NTRACK], isEle_ref[NTRACK];
+        tk2em_step1_ref(emcalo, track, isEle_ref, outpho_ref);
+        tk2em_step1(emcalo, track, isEle, outpho);
+        int errors = 0; int ntot = 0, npho = 0, nch = 0, nneu = 0;
+#if 1
+        for (int i = 0; i < NTRACK; ++i) {
+            if (track[i].hwPt > 0 && isEle[i] != isEle_ref[i]) { 
+                printf("Electron mismatch for track %2d (hw %d, ref %d)\n", i, int(isEle[i]), int(isEle_ref[i]));
+                errors++;
+            }
+        }
+        for (int i = 0; i < NPHOTON; ++i) {
+            if (!pf_equals(outpho_ref[i], outpho[i], "Photon", i)) errors++;
+            if (outpho_ref[i].hwPt > 0) { ntot++; npho++; }
+        }
+
+#else
+        for (int i = 0; i < NTRACK; ++i) {
+            if (!pf_equals(outch_ref[i], outch[i], "PF Charged", i)) errors++;
+            if (outch_ref[i].hwPt > 0) { ntot++; nch++; }
+        }
+        for (int i = 0; i < NSELCALO; ++i) {
+            if (!pf_equals(outne_ref[i], outne[i], "PF Neutral", i)) errors++;
+            if (outne_ref[i].hwPt > 0) { ntot++; nneu++; }
+        }
+#endif
+        if (errors != 0) {
+            printf("Error in computing test %d (%d)\n", test, errors);
+            for (int i = 0; i < NCALO; ++i) {
+                printf("calo  %3d, hwPt % 7d   hwEmPt  % 7d    hwEta %+7d   hwPhi %+7d\n", i, int(calo[i].hwPt), int(calo[i].hwEmPt), int(calo[i].hwEta), int(calo[i].hwPhi));
+            }
+            for (int i = 0; i < NEMCALO; ++i) {
+                printf("em    %3d, hwPt % 7d   hwPtErr % 7d    hwEta %+7d   hwPhi %+7d\n", i, int(emcalo[i].hwPt), int(emcalo[i].hwPtErr), int(emcalo[i].hwEta), int(emcalo[i].hwPhi));
+            }
+            for (int i = 0; i < NTRACK; ++i) {
+                printf("track %3d, hwPt % 7d   hwPtErr % 7d    hwEta %+7d   hwPhi %+7d     hwZ0 %+7d\n", i, int(track[i].hwPt), int(track[i].hwPtErr), int(track[i].hwEta), int(track[i].hwPhi), int(track[i].hwZ0));
+            }
+            for (int i = 0; i < NTRACK; ++i) {
+                printf("charged pf %3d, hwPt % 7d % 7d   hwEta %+7d %+7d   hwPhi %+7d %+7d   hwId %1d %1d      hwZ0 %+7d %+7d\n", i,
+                    int(outch_ref[i].hwPt), int(outch[i].hwPt), int(outch_ref[i].hwEta), int(outch[i].hwEta),
+                    int(outch_ref[i].hwPhi), int(outch[i].hwPhi), int(outch_ref[i].hwId), int(outch[i].hwId),
+                    int(outch_ref[i].hwZ0), int(outch[i].hwZ0));
+            }
+            for (int i = 0; i < NSELCALO; ++i) {
+                printf("neutral pf %3d, hwPt % 7d % 7d   hwEta %+7d %+7d   hwPhi %+7d %+7d   hwId %1d %1d\n", i,
+                    int(outne_ref[i].hwPt), int(outne[i].hwPt), int(outne_ref[i].hwEta), int(outne[i].hwEta),
+                    int(outne_ref[i].hwPhi), int(outne[i].hwPhi), int(outne_ref[i].hwId), int(outne[i].hwId));
+            }
+            for (int i = 0; i < NPHOTON; ++i) {
+                printf("photon  pf %3d, hwPt % 7d % 7d   hwEta %+7d %+7d   hwPhi %+7d %+7d   hwId %1d %1d\n", i,
+                    int(outpho_ref[i].hwPt), int(outpho[i].hwPt), int(outpho_ref[i].hwEta), int(outpho[i].hwEta),
+                    int(outpho_ref[i].hwPhi), int(outpho[i].hwPhi), int(outpho_ref[i].hwId), int(outpho[i].hwId));
+            }
+
+            return 1;
+        } else {
+            printf("Passed test %d (%d, %d, %d, %d)\n", test, ntot, nch, npho, nneu);
+        }
+
+    }
+    return 0;
+}

--- a/simple_pfalgo3_test.cpp
+++ b/simple_pfalgo3_test.cpp
@@ -5,6 +5,19 @@
 
 #define NTEST 500
 
+bool had_equals(const HadCaloObj &out_ref, const HadCaloObj &out, const char *what, int idx) {
+    bool ret;
+    if (out_ref.hwPt == 0) {
+        ret = (out.hwPt == 0);
+    } else {
+        ret = (out_ref.hwPt == out.hwPt && out_ref.hwEmPt == out.hwEmPt && out_ref.hwEta == out.hwEta && out_ref.hwPhi == out.hwPhi && out_ref.hwIsEM  == out.hwIsEM);
+    }
+    if  (!ret) {
+        printf("Mismatch at %s[%3d], hwPt % 7d % 7d   hwEmPt % 7d % 7d   hwEta %+7d %+7d   hwPhi %+7d %+7d   hwId %1d %1d\n", what, idx,
+                int(out_ref.hwPt), int(out.hwPt), int(out_ref.hwEmPt), int(out.hwEmPt), int(out_ref.hwEta), int(out.hwEta), int(out_ref.hwPhi), int(out.hwPhi), int(out_ref.hwIsEM), int(out.hwIsEM));
+    }
+    return ret;
+}
 bool pf_equals(const PFChargedObj &out_ref, const PFChargedObj &out, const char *what, int idx) {
     bool ret;
     if (out_ref.hwPt == 0) {
@@ -38,12 +51,15 @@ bool pf_equals(const PFNeutralObj &out_ref, const PFNeutralObj &out, const char 
     }
     return ret;
 }
+
+
 int main() {
 
     //RandomPFInputs inputs(37); // 37 is a good random number
     DiscretePFInputs inputs("regions_TTbar_PU140.dump");
     
     HadCaloObj calo[NCALO]; EmCaloObj emcalo[NEMCALO]; TkObj track[NTRACK]; z0_t hwZPV;
+    HadCaloObj calo_subem[NCALO], calo_subem_ref[NCALO]; 
     PFChargedObj outch[NTRACK], outch_ref[NTRACK];
     PFNeutralObj outpho[NPHOTON], outpho_ref[NPHOTON];
     PFNeutralObj outne[NSELCALO], outne_ref[NSELCALO];
@@ -53,7 +69,7 @@ int main() {
             track[i].hwPt = 0; track[i].hwPtErr = 0; track[i].hwEta = 0; track[i].hwPhi = 0; track[i].hwZ0 = 0;
         }
         for (int i = 0; i < NCALO; ++i) {
-            calo[i].hwPt = 0; calo[i].hwEmPt = 0; calo[i].hwEta = 0; calo[i].hwPhi = 0;
+            calo[i].hwPt = 0; calo[i].hwEmPt = 0; calo[i].hwEta = 0; calo[i].hwPhi = 0; calo[i].hwIsEM = 0; 
         }
         for (int i = 0; i < NEMCALO; ++i) {
             emcalo[i].hwPt = 0;emcalo[i].hwPtErr = 0;  emcalo[i].hwEta = 0; emcalo[i].hwPhi = 0;
@@ -62,29 +78,48 @@ int main() {
 
         if (!inputs.nextRegion(calo, emcalo, track, hwZPV)) break;
 
-        //pfalgo3_ref(calo, track, outch_ref, outne_ref);
-        //tk2calo_algo(calo, track, outch, outne);
+#if defined(TESTCALO)
+        pfalgo3_calo_ref(calo, track, outch_ref, outne_ref);
+        pfalgo3_calo(calo, track, outch, outne);
+#elif defined(TESTEM)
         bool isEle[NTRACK], isEle_ref[NTRACK];
-        tk2em_step1_ref(emcalo, track, isEle_ref, outpho_ref);
-        tk2em_step1(emcalo, track, isEle, outpho);
+        pfalgo3_em_ref(emcalo, calo, track, isEle_ref, outpho_ref, calo_subem_ref);
+        pfalgo3_em(emcalo, calo, track, isEle, outpho, calo_subem);
+#else
+        pfalgo3_full_ref(emcalo, calo, track, outch_ref, outpho_ref, outne_ref);
+        pfalgo3_full(emcalo, calo, track, outch, outpho, outne);
+#endif
+
         int errors = 0; int ntot = 0, npho = 0, nch = 0, nneu = 0;
-#if 1
+
+#if defined(TESTCALO) || defined(TESTFULL)
+        // check charged hadrons
+        for (int i = 0; i < NTRACK; ++i) {
+            if (!pf_equals(outch_ref[i], outch[i], "PF Charged", i)) errors++;
+            if (outch_ref[i].hwPt > 0) { ntot++; nch++; }
+        }
+#endif
+#if defined(TESTEM)
+        // check electron flags 
         for (int i = 0; i < NTRACK; ++i) {
             if (track[i].hwPt > 0 && isEle[i] != isEle_ref[i]) { 
                 printf("Electron mismatch for track %2d (hw %d, ref %d)\n", i, int(isEle[i]), int(isEle_ref[i]));
                 errors++;
             }
         }
+        // check EM-subtracted calo
+        for (int i = 0; i < NCALO; ++i) {
+            if (!had_equals(calo_subem_ref[i], calo_subem[i], "Calo non-EM", i)) errors++;
+        }
+#endif
+#if defined(TESTEM) || defined(TESTFULL)
+        // check photon 
         for (int i = 0; i < NPHOTON; ++i) {
             if (!pf_equals(outpho_ref[i], outpho[i], "Photon", i)) errors++;
             if (outpho_ref[i].hwPt > 0) { ntot++; npho++; }
         }
-
-#else
-        for (int i = 0; i < NTRACK; ++i) {
-            if (!pf_equals(outch_ref[i], outch[i], "PF Charged", i)) errors++;
-            if (outch_ref[i].hwPt > 0) { ntot++; nch++; }
-        }
+#endif
+#if defined(TESTCALO) || defined(TESTFULL)
         for (int i = 0; i < NSELCALO; ++i) {
             if (!pf_equals(outne_ref[i], outne[i], "PF Neutral", i)) errors++;
             if (outne_ref[i].hwPt > 0) { ntot++; nneu++; }
@@ -93,7 +128,7 @@ int main() {
         if (errors != 0) {
             printf("Error in computing test %d (%d)\n", test, errors);
             for (int i = 0; i < NCALO; ++i) {
-                printf("calo  %3d, hwPt % 7d   hwEmPt  % 7d    hwEta %+7d   hwPhi %+7d\n", i, int(calo[i].hwPt), int(calo[i].hwEmPt), int(calo[i].hwEta), int(calo[i].hwPhi));
+                printf("calo  %3d, hwPt % 7d   hwEmPt  % 7d    hwEta %+7d   hwPhi %+7d   hwIsEM %1d\n", i, int(calo[i].hwPt), int(calo[i].hwEmPt), int(calo[i].hwEta), int(calo[i].hwPhi), int(calo[i].hwIsEM));
             }
             for (int i = 0; i < NEMCALO; ++i) {
                 printf("em    %3d, hwPt % 7d   hwPtErr % 7d    hwEta %+7d   hwPhi %+7d\n", i, int(emcalo[i].hwPt), int(emcalo[i].hwPtErr), int(emcalo[i].hwEta), int(emcalo[i].hwPhi));
@@ -101,22 +136,33 @@ int main() {
             for (int i = 0; i < NTRACK; ++i) {
                 printf("track %3d, hwPt % 7d   hwPtErr % 7d    hwEta %+7d   hwPhi %+7d     hwZ0 %+7d\n", i, int(track[i].hwPt), int(track[i].hwPtErr), int(track[i].hwEta), int(track[i].hwPhi), int(track[i].hwZ0));
             }
+#if defined(TESTEM)
+            for (int i = 0; i < NCALO; ++i) {
+                printf("no-em %3d, hwPt % 7d   hwEmPt  % 7d    hwEta %+7d   hwPhi %+7d\n", i, int(calo_subem[i].hwPt), int(calo_subem[i].hwEmPt), int(calo_subem[i].hwEta), int(calo_subem[i].hwPhi));
+            }
+#endif
+#if defined(TESTCALO) || defined(TESTFULL)
             for (int i = 0; i < NTRACK; ++i) {
                 printf("charged pf %3d, hwPt % 7d % 7d   hwEta %+7d %+7d   hwPhi %+7d %+7d   hwId %1d %1d      hwZ0 %+7d %+7d\n", i,
                     int(outch_ref[i].hwPt), int(outch[i].hwPt), int(outch_ref[i].hwEta), int(outch[i].hwEta),
                     int(outch_ref[i].hwPhi), int(outch[i].hwPhi), int(outch_ref[i].hwId), int(outch[i].hwId),
                     int(outch_ref[i].hwZ0), int(outch[i].hwZ0));
             }
-            for (int i = 0; i < NSELCALO; ++i) {
-                printf("neutral pf %3d, hwPt % 7d % 7d   hwEta %+7d %+7d   hwPhi %+7d %+7d   hwId %1d %1d\n", i,
-                    int(outne_ref[i].hwPt), int(outne[i].hwPt), int(outne_ref[i].hwEta), int(outne[i].hwEta),
-                    int(outne_ref[i].hwPhi), int(outne[i].hwPhi), int(outne_ref[i].hwId), int(outne[i].hwId));
-            }
+#endif
+#if defined(TESTEM) || defined(TESTFULL)
             for (int i = 0; i < NPHOTON; ++i) {
                 printf("photon  pf %3d, hwPt % 7d % 7d   hwEta %+7d %+7d   hwPhi %+7d %+7d   hwId %1d %1d\n", i,
                     int(outpho_ref[i].hwPt), int(outpho[i].hwPt), int(outpho_ref[i].hwEta), int(outpho[i].hwEta),
                     int(outpho_ref[i].hwPhi), int(outpho[i].hwPhi), int(outpho_ref[i].hwId), int(outpho[i].hwId));
             }
+#endif
+#if defined(TESTCALO) || defined(TESTFULL)
+            for (int i = 0; i < NSELCALO; ++i) {
+                printf("neutral pf %3d, hwPt % 7d % 7d   hwEta %+7d %+7d   hwPhi %+7d %+7d   hwId %1d %1d\n", i,
+                    int(outne_ref[i].hwPt), int(outne[i].hwPt), int(outne_ref[i].hwEta), int(outne[i].hwEta),
+                    int(outne_ref[i].hwPhi), int(outne[i].hwPhi), int(outne_ref[i].hwId), int(outne[i].hwId));
+            }
+#endif
 
             return 1;
         } else {

--- a/src/data.h
+++ b/src/data.h
@@ -6,10 +6,10 @@
 typedef ap_int<16> pt_t;
 typedef ap_int<9>  etaphi_t;
 typedef ap_int<5>  vtx_t;
-typedef ap_int<2>  particleid_t;
+typedef ap_uint<2>  particleid_t;
 typedef ap_int<10> z0_t;  // 40cm / 0.1
 		
-enum PID { PID_Charged=0, PID_Neutral=1, PID_Photon=2 };
+enum PID { PID_Charged=0, PID_Neutral=1, PID_Photon=2, PID_Electron=3 };
 
 // VERTEXING
 #define NVTXBINS  15
@@ -35,6 +35,7 @@ struct CaloObj {
 };
 struct HadCaloObj : public CaloObj {
 	pt_t hwEmPt;
+        bool hwIsEM;
 };
 struct EmCaloObj {
 	pt_t hwPt, hwPtErr;

--- a/src/data.h
+++ b/src/data.h
@@ -9,7 +9,7 @@ typedef ap_int<5>  vtx_t;
 typedef ap_int<2>  particleid_t;
 typedef ap_int<10> z0_t;  // 40cm / 0.1
 		
-enum PID { PID_Charged=0, PID_Neutral=1 };
+enum PID { PID_Charged=0, PID_Neutral=1, PID_Photon=2 };
 
 // VERTEXING
 #define NVTXBINS  15
@@ -19,9 +19,11 @@ enum PID { PID_Charged=0, PID_Neutral=1 };
 #define VTXPTMAX  200
 
 // PF
-#define NTRACK 8
+#define NTRACK 12
 #define NCALO 12
-#define NSELCALO 15
+#define NEMCALO 12
+#define NPHOTON NEMCALO
+#define NSELCALO 10
 
 // PUPPI & CHS
 #define NPVTRACK 7
@@ -31,6 +33,14 @@ struct CaloObj {
 	pt_t hwPt;
 	etaphi_t hwEta, hwPhi; // relative to the region center, at calo
 };
+struct HadCaloObj : public CaloObj {
+	pt_t hwEmPt;
+};
+struct EmCaloObj {
+	pt_t hwPt, hwPtErr;
+	etaphi_t hwEta, hwPhi; // relative to the region center, at calo
+};
+
 struct TkObj {
 	pt_t hwPt, hwPtErr;
 	etaphi_t hwEta, hwPhi; // relative to the region center, at calo

--- a/src/simple_pfalgo3.cpp
+++ b/src/simple_pfalgo3.cpp
@@ -6,7 +6,8 @@
 #endif
 
 typedef ap_uint<7> tk2em_dr_t;
-typedef ap_uint<12> tk2calo_dr_t;
+typedef ap_uint<10> tk2calo_dr_t;
+typedef ap_uint<10> em2calo_dr_t;
 
 int dr2_int(etaphi_t eta1, etaphi_t phi1, etaphi_t eta2, etaphi_t phi2) {
     etaphi_t deta = (eta1-eta2);
@@ -36,6 +37,7 @@ void tk2calo_drvals(HadCaloObj calo[NCALO], TkObj track[NTRACK], tk2calo_dr_t ca
     const tk2calo_dr_t eDR2MAX = DR2MAX;
     for (int it = 0; it < NTRACK; ++it) {
         pt_t caloPtMin = track[it].hwPt - 2*(track[it].hwPtErr);
+        if (caloPtMin < 0) caloPtMin = 0;
         for (int icalo = 0; icalo < NCALO; ++icalo) {
             if (calo[icalo].hwPt > caloPtMin) {
                 calo_track_drval[it][icalo] = dr2_int_cap(track[it].hwEta, track[it].hwPhi, calo[icalo].hwEta, calo[icalo].hwPhi, eDR2MAX);
@@ -45,6 +47,21 @@ void tk2calo_drvals(HadCaloObj calo[NCALO], TkObj track[NTRACK], tk2calo_dr_t ca
         }
     }
 }
+template<int DR2MAX>
+void em2calo_drvals(HadCaloObj hadcalo[NCALO], EmCaloObj emcalo[NEMCALO], em2calo_dr_t hadcalo_emcalo_drval[NEMCALO][NCALO]) {
+    const em2calo_dr_t eDR2MAX = DR2MAX;
+    for (int it = 0; it < NEMCALO; ++it) {
+        pt_t hadcaloEmPtMin = (emcalo[it].hwPt >> 1);
+        for (int icalo = 0; icalo < NCALO; ++icalo) {
+            if (hadcalo[icalo].hwEmPt > hadcaloEmPtMin) {
+                hadcalo_emcalo_drval[it][icalo] = dr2_int_cap(emcalo[it].hwEta, emcalo[it].hwPhi, hadcalo[icalo].hwEta, hadcalo[icalo].hwPhi, eDR2MAX);
+            } else {
+                hadcalo_emcalo_drval[it][icalo] = eDR2MAX;
+            }
+        }
+    }
+}
+
 template<int DR2MAX, int NTK, int NCA, typename DR_T>
 void pick_closest(DR_T calo_track_drval[NTK][NCA], ap_uint<NCA> calo_track_link_bit[NTK]) {
     const DR_T eDR2MAX = DR2MAX;
@@ -61,13 +78,7 @@ void pick_closest(DR_T calo_track_drval[NTK][NCA], ap_uint<NCA> calo_track_link_
     }
 }
 void tk2calo_link(HadCaloObj calo[NCALO], TkObj track[NTRACK], ap_uint<NCALO> calo_track_link_bit[NTRACK]) {
-    #pragma HLS ARRAY_PARTITION variable=calo complete
-    #pragma HLS ARRAY_PARTITION variable=track complete
-    #pragma HLS ARRAY_PARTITION variable=calo_track_link_bit complete dim=0
-
-    #pragma HLS pipeline II=5
-
-    const int DR2MAX = 2101;
+    const int DR2MAX = PFALGO3_DR2MAX_TK_CALO;
     tk2calo_dr_t drvals[NTRACK][NCALO];
     #pragma HLS ARRAY_PARTITION variable=drvals complete dim=0
 
@@ -75,19 +86,22 @@ void tk2calo_link(HadCaloObj calo[NCALO], TkObj track[NTRACK], ap_uint<NCALO> ca
     pick_closest<DR2MAX,NTRACK,NCALO>(drvals, calo_track_link_bit);
 }
 void tk2em_link(EmCaloObj calo[NEMCALO], TkObj track[NTRACK], ap_uint<NEMCALO> calo_track_link_bit[NTRACK]) {
-    #pragma HLS ARRAY_PARTITION variable=calo complete
-    #pragma HLS ARRAY_PARTITION variable=track complete
-    #pragma HLS ARRAY_PARTITION variable=calo_track_link_bit complete dim=0
-
-    #pragma HLS pipeline II=5
-
-    const int DR2MAX = 84;
+    const int DR2MAX = PFALGO3_DR2MAX_TK_EM;
     tk2em_dr_t drvals[NTRACK][NCALO];
     #pragma HLS ARRAY_PARTITION variable=drvals complete dim=0
 
     tk2em_drvals<DR2MAX>(calo, track, drvals);
     pick_closest<DR2MAX,NTRACK,NEMCALO>(drvals, calo_track_link_bit);
 }
+void em2calo_link(EmCaloObj emcalo[NEMCALO], HadCaloObj hadcalo[NCALO], ap_uint<NCALO> em_calo_link_bit[NCALO]) {
+    const int DR2MAX = PFALGO3_DR2MAX_EM_CALO;
+    em2calo_dr_t drvals[NEMCALO][NCALO];
+    #pragma HLS ARRAY_PARTITION variable=drvals complete dim=0
+
+    em2calo_drvals<DR2MAX>(hadcalo, emcalo, drvals);
+    pick_closest<DR2MAX,NEMCALO,NCALO>(drvals, em_calo_link_bit);
+}
+
 
 
 void tk2calo_tkerr2(TkObj track[NTRACK], int tkerr2[NTRACK]) {
@@ -106,6 +120,18 @@ void tk2calo_sumtk(TkObj track[NTRACK], int tkerr2[NTRACK], ap_uint<NCALO> calo_
         sumtkerr2[icalo] = sumerr;
     }
 }
+void tk2calo_sumtk(TkObj track[NTRACK], bool isEle[NTRACK], int tkerr2[NTRACK], ap_uint<NCALO> calo_track_link_bit[NTRACK], pt_t sumtk[NCALO], int sumtkerr2[NCALO]) {
+    for (int icalo = 0; icalo < NCALO; ++icalo) {
+        pt_t sum = 0;
+        int sumerr = 0;
+        for (int it = 0; it < NTRACK; ++it) {
+            if (!isEle[it] && calo_track_link_bit[it][icalo]) { sum += track[it].hwPt; sumerr += tkerr2[it]; }
+        }
+        sumtk[icalo] = sum;
+        sumtkerr2[icalo] = sumerr;
+    }
+}
+
 void tk2em_sumtk(TkObj track[NTRACK], ap_uint<NEMCALO> calo_track_link_bit[NTRACK], pt_t sumtk[NEMCALO]) {
     for (int icalo = 0; icalo < NEMCALO; ++icalo) {
         pt_t sum = 0;
@@ -116,9 +142,20 @@ void tk2em_sumtk(TkObj track[NTRACK], ap_uint<NEMCALO> calo_track_link_bit[NTRAC
     }
 }
 
+void em2calo_sumem(EmCaloObj emcalo[NEMCALO], bool isEM[NEMCALO], ap_uint<NCALO> em_had_link_bit[NTRACK], pt_t sumem[NEMCALO]) {
+    for (int icalo = 0; icalo < NCALO; ++icalo) {
+        pt_t sum = 0;
+        for (int iem = 0; iem < NEMCALO; ++iem) {
+            if (isEM[iem] && em_had_link_bit[iem][icalo]) { sum += emcalo[iem].hwPt; }
+        }
+        sumem[icalo] = sum;
+    }
+}
+
+
 
 void tk2calo_tkalgo(TkObj track[NTRACK], ap_uint<NCALO> calo_track_link_bit[NTRACK], PFChargedObj pfout[NTRACK]) {
-    const pt_t TKPT_MAX = 80; // 20 * PT_SCALE;
+    const pt_t TKPT_MAX = PFALGO3_TK_MAXINVPT; // 20 * PT_SCALE;
     for (int it = 0; it < NTRACK; ++it) {
         bool good = (track[it].hwPt < TKPT_MAX) || calo_track_link_bit[it].or_reduce();
         if (good) {
@@ -136,6 +173,26 @@ void tk2calo_tkalgo(TkObj track[NTRACK], ap_uint<NCALO> calo_track_link_bit[NTRA
         }
     }
 }
+void tk2calo_tkalgo(TkObj track[NTRACK], bool isEle[NTRACK], ap_uint<NCALO> calo_track_link_bit[NTRACK], PFChargedObj pfout[NTRACK]) {
+    const pt_t TKPT_MAX = PFALGO3_TK_MAXINVPT; // 20 * PT_SCALE;
+    for (int it = 0; it < NTRACK; ++it) {
+        bool good = isEle[it] || (track[it].hwPt < TKPT_MAX) || calo_track_link_bit[it].or_reduce();
+        if (good) {
+            pfout[it].hwPt  = track[it].hwPt;
+            pfout[it].hwEta = track[it].hwEta;
+            pfout[it].hwPhi = track[it].hwPhi;
+            pfout[it].hwId  = isEle[it] ? PID_Electron : PID_Charged;
+            pfout[it].hwZ0  = track[it].hwZ0;
+        } else {
+            pfout[it].hwPt  = 0;
+            pfout[it].hwEta = 0;
+            pfout[it].hwPhi = 0;
+            pfout[it].hwId  = 0;
+            pfout[it].hwZ0  = 0;
+        }
+    }
+}
+
 
 void tk2calo_caloalgo(HadCaloObj calo[NCALO], pt_t sumtk[NCALO], int sumtkerr2[NCALO], PFNeutralObj pfout[NCALO]) {
     for (int icalo = 0; icalo < NCALO; ++icalo) {
@@ -194,8 +251,28 @@ void tk2em_photons(EmCaloObj calo[NEMCALO], pt_t photonPt[NEMCALO], PFNeutralObj
     }
 }
 
+void em2calo_sub(HadCaloObj calo[NCALO], pt_t sumem[NCALO], HadCaloObj calo_out[NCALO]) {
+    for (int icalo = 0; icalo < NCALO; ++icalo) {
+        pt_t ptsub = calo[icalo].hwPt   - sumem[icalo];
+        pt_t emsub = calo[icalo].hwEmPt - sumem[icalo];
+        if ((ptsub < (calo[icalo].hwPt >> 4)) || 
+                (calo[icalo].hwIsEM && (emsub < (calo[icalo].hwEmPt>>3)))) {
+            calo_out[icalo].hwPt   = 0;
+            calo_out[icalo].hwEmPt = 0;
+            calo_out[icalo].hwEta  = 0;
+            calo_out[icalo].hwPhi  = 0;
+            calo_out[icalo].hwIsEM = 0;
+        } else {
+            calo_out[icalo].hwPt   = ptsub;
+            calo_out[icalo].hwEmPt = (emsub > 0 ? emsub : pt_t(0));
+            calo_out[icalo].hwEta  = calo[icalo].hwEta;
+            calo_out[icalo].hwPhi  = calo[icalo].hwPhi;
+            calo_out[icalo].hwIsEM = calo[icalo].hwIsEM;
+        }
+    }
+}
 
-void tk2calo_algo(HadCaloObj calo[NCALO], TkObj track[NTRACK], PFChargedObj outch[NTRACK], PFNeutralObj outne[NSELCALO]) {
+void pfalgo3_calo(HadCaloObj calo[NCALO], TkObj track[NTRACK], PFChargedObj outch[NTRACK], PFNeutralObj outne[NSELCALO]) {
     #pragma HLS ARRAY_PARTITION variable=calo complete
     #pragma HLS ARRAY_PARTITION variable=track complete
     #pragma HLS ARRAY_PARTITION variable=outch complete
@@ -224,12 +301,13 @@ void tk2calo_algo(HadCaloObj calo[NCALO], TkObj track[NTRACK], PFChargedObj outc
     ptsort_hwopt<PFNeutralObj,NCALO,NSELCALO>(outne_all, outne);
 }
 
-void tk2em_step1(EmCaloObj calo[NEMCALO], TkObj track[NTRACK], bool isEle[NTRACK], PFNeutralObj outpho[NPHOTON]) {
+void pfalgo3_em(EmCaloObj calo[NEMCALO], HadCaloObj hadcalo[NCALO], TkObj track[NTRACK], bool isEle[NTRACK], PFNeutralObj outpho[NPHOTON], HadCaloObj hadcalo_out[NCALO]) {
     #pragma HLS ARRAY_PARTITION variable=calo complete
+    #pragma HLS ARRAY_PARTITION variable=hadcalo complete
     #pragma HLS ARRAY_PARTITION variable=track complete
     #pragma HLS ARRAY_PARTITION variable=isEle complete
-    #pragma HLS ARRAY_PARTITION variable=isEM complete
     #pragma HLS ARRAY_PARTITION variable=outpho complete
+    #pragma HLS ARRAY_PARTITION variable=hadcalo_out complete
 
     #pragma HLS pipeline II=5
 
@@ -250,6 +328,80 @@ void tk2em_step1(EmCaloObj calo[NEMCALO], TkObj track[NTRACK], bool isEle[NTRACK
     tk2em_emalgo(calo, sumtk, isEM, photonPt);
     tk2em_photons(calo, photonPt, outpho);
     tk2em_elealgo(em_track_link_bit, isEM, isEle);
+
+    ap_uint<NCALO> em_calo_link_bit[NEMCALO];
+    #pragma HLS ARRAY_PARTITION variable=em_calo_link_bit complete
+    em2calo_link(calo, hadcalo, em_calo_link_bit);
+
+    pt_t sumem[NCALO]; 
+    #pragma HLS ARRAY_PARTITION variable=sumem complete
+    em2calo_sumem(calo, isEM, em_calo_link_bit, sumem);
+    em2calo_sub(hadcalo, sumem, hadcalo_out);
+}
+
+void pfalgo3_full(EmCaloObj calo[NEMCALO], HadCaloObj hadcalo[NCALO], TkObj track[NTRACK], PFChargedObj outch[NTRACK], PFNeutralObj outpho[NPHOTON], PFNeutralObj outne[NSELCALO]) {
+    #pragma HLS ARRAY_PARTITION variable=calo complete
+    #pragma HLS ARRAY_PARTITION variable=hadcalo complete
+    #pragma HLS ARRAY_PARTITION variable=track complete
+    #pragma HLS ARRAY_PARTITION variable=outch complete
+    #pragma HLS ARRAY_PARTITION variable=outpho complete
+    #pragma HLS ARRAY_PARTITION variable=outne complete
+
+    #pragma HLS pipeline II=5
+
+    ap_uint<NEMCALO> em_track_link_bit[NTRACK];
+    #pragma HLS ARRAY_PARTITION variable=em_track_link_bit complete
+    tk2em_link(calo, track, em_track_link_bit);
+
+    pt_t sumtk2em[NEMCALO]; 
+    #pragma HLS ARRAY_PARTITION variable=sumtk2em complete
+
+    pt_t photonPt[NEMCALO];
+    #pragma HLS ARRAY_PARTITION variable=photonPt complete
+
+    bool isEM[NEMCALO];
+    #pragma HLS ARRAY_PARTITION variable=isEM complete
+
+    tk2em_sumtk(track, em_track_link_bit, sumtk2em);
+    tk2em_emalgo(calo, sumtk2em, isEM, photonPt);
+    tk2em_photons(calo, photonPt, outpho);
+
+    bool isEle[NTRACK];
+    #pragma HLS ARRAY_PARTITION variable=isEle complete
+    tk2em_elealgo(em_track_link_bit, isEM, isEle);
+
+    ap_uint<NCALO> em_calo_link_bit[NEMCALO];
+    #pragma HLS ARRAY_PARTITION variable=em_calo_link_bit complete
+    em2calo_link(calo, hadcalo, em_calo_link_bit);
+
+    pt_t sumem[NCALO]; 
+    #pragma HLS ARRAY_PARTITION variable=sumem complete
+    em2calo_sumem(calo, isEM, em_calo_link_bit, sumem);
+
+    HadCaloObj hadcalo_sub[NCALO];
+    #pragma HLS ARRAY_PARTITION variable=hadcalo_sub complete
+
+    em2calo_sub(hadcalo, sumem, hadcalo_sub);
+
+    ap_uint<NCALO> calo_track_link_bit[NTRACK];
+    #pragma HLS ARRAY_PARTITION variable=calo_track_link_bit complete
+    tk2calo_link(hadcalo_sub, track, calo_track_link_bit);
+
+    int tkerr2[NTRACK];
+    #pragma HLS ARRAY_PARTITION variable=tkerr2 complete
+    tk2calo_tkerr2(track, tkerr2);
+
+    pt_t sumtk[NCALO]; int sumtkerr2[NCALO];
+    #pragma HLS ARRAY_PARTITION variable=sumtk complete
+    #pragma HLS ARRAY_PARTITION variable=sumtkerr2 complete
+
+    tk2calo_tkalgo(track, isEle, calo_track_link_bit, outch);
+    tk2calo_sumtk(track, isEle, tkerr2, calo_track_link_bit, sumtk, sumtkerr2);
+
+    PFNeutralObj outne_all[NCALO];
+    #pragma HLS ARRAY_PARTITION variable=outne_all complete
+    tk2calo_caloalgo(hadcalo_sub, sumtk, sumtkerr2, outne_all);
+    ptsort_hwopt<PFNeutralObj,NCALO,NSELCALO>(outne_all, outne);
 }
 
 

--- a/src/simple_pfalgo3.cpp
+++ b/src/simple_pfalgo3.cpp
@@ -1,0 +1,256 @@
+#include "simple_pfalgo3.h"
+#include <cmath>
+#include <cassert>
+#ifndef __SYNTHESIS__
+#include <cstdio>
+#endif
+
+typedef ap_uint<7> tk2em_dr_t;
+typedef ap_uint<12> tk2calo_dr_t;
+
+int dr2_int(etaphi_t eta1, etaphi_t phi1, etaphi_t eta2, etaphi_t phi2) {
+    etaphi_t deta = (eta1-eta2);
+    etaphi_t dphi = (phi1-phi2);
+    return deta*deta + dphi*dphi;
+}
+template<int NB>
+ap_uint<NB> dr2_int_cap(etaphi_t eta1, etaphi_t phi1, etaphi_t eta2, etaphi_t phi2, ap_uint<NB> max) {
+    etaphi_t deta = (eta1-eta2);
+    etaphi_t dphi = (phi1-phi2);
+    int dr2 = deta*deta + dphi*dphi;
+    return (dr2 < int(max) ? ap_uint<NB>(dr2) : max);
+}
+
+template<int DR2MAX>
+void tk2em_drvals(EmCaloObj calo[NEMCALO], TkObj track[NTRACK], tk2em_dr_t calo_track_drval[NTRACK][NCALO]) {
+    const tk2em_dr_t eDR2MAX = DR2MAX;
+    for (int it = 0; it < NTRACK; ++it) {
+        for (int icalo = 0; icalo < NEMCALO; ++icalo) {
+            calo_track_drval[it][icalo] = dr2_int_cap(track[it].hwEta, track[it].hwPhi, calo[icalo].hwEta, calo[icalo].hwPhi, eDR2MAX);
+        }
+    }
+}
+
+template<int DR2MAX>
+void tk2calo_drvals(HadCaloObj calo[NCALO], TkObj track[NTRACK], tk2calo_dr_t calo_track_drval[NTRACK][NCALO]) {
+    const tk2calo_dr_t eDR2MAX = DR2MAX;
+    for (int it = 0; it < NTRACK; ++it) {
+        pt_t caloPtMin = track[it].hwPt - 2*(track[it].hwPtErr);
+        for (int icalo = 0; icalo < NCALO; ++icalo) {
+            if (calo[icalo].hwPt > caloPtMin) {
+                calo_track_drval[it][icalo] = dr2_int_cap(track[it].hwEta, track[it].hwPhi, calo[icalo].hwEta, calo[icalo].hwPhi, eDR2MAX);
+            } else {
+                calo_track_drval[it][icalo] = eDR2MAX;
+            }
+        }
+    }
+}
+template<int DR2MAX, int NTK, int NCA, typename DR_T>
+void pick_closest(DR_T calo_track_drval[NTK][NCA], ap_uint<NCA> calo_track_link_bit[NTK]) {
+    const DR_T eDR2MAX = DR2MAX;
+    for (int it = 0; it < NTK; ++it) {
+        for (int icalo = 0; icalo < NCA; ++icalo) {
+            DR_T mydr = calo_track_drval[it][icalo];
+            bool link = (mydr != eDR2MAX);
+            for (int j = 0; j < NCA; ++j) {
+                if (icalo <= j) link = link && (calo_track_drval[it][j] >= mydr);
+                else            link = link && (calo_track_drval[it][j] >  mydr);
+            }
+            calo_track_link_bit[it][icalo] = link;
+        }
+    }
+}
+void tk2calo_link(HadCaloObj calo[NCALO], TkObj track[NTRACK], ap_uint<NCALO> calo_track_link_bit[NTRACK]) {
+    #pragma HLS ARRAY_PARTITION variable=calo complete
+    #pragma HLS ARRAY_PARTITION variable=track complete
+    #pragma HLS ARRAY_PARTITION variable=calo_track_link_bit complete dim=0
+
+    #pragma HLS pipeline II=5
+
+    const int DR2MAX = 2101;
+    tk2calo_dr_t drvals[NTRACK][NCALO];
+    #pragma HLS ARRAY_PARTITION variable=drvals complete dim=0
+
+    tk2calo_drvals<DR2MAX>(calo, track, drvals);
+    pick_closest<DR2MAX,NTRACK,NCALO>(drvals, calo_track_link_bit);
+}
+void tk2em_link(EmCaloObj calo[NEMCALO], TkObj track[NTRACK], ap_uint<NEMCALO> calo_track_link_bit[NTRACK]) {
+    #pragma HLS ARRAY_PARTITION variable=calo complete
+    #pragma HLS ARRAY_PARTITION variable=track complete
+    #pragma HLS ARRAY_PARTITION variable=calo_track_link_bit complete dim=0
+
+    #pragma HLS pipeline II=5
+
+    const int DR2MAX = 84;
+    tk2em_dr_t drvals[NTRACK][NCALO];
+    #pragma HLS ARRAY_PARTITION variable=drvals complete dim=0
+
+    tk2em_drvals<DR2MAX>(calo, track, drvals);
+    pick_closest<DR2MAX,NTRACK,NEMCALO>(drvals, calo_track_link_bit);
+}
+
+
+void tk2calo_tkerr2(TkObj track[NTRACK], int tkerr2[NTRACK]) {
+    for (int it = 0; it < NTRACK; ++it) {
+        tkerr2[it] = (track[it].hwPtErr * track[it].hwPtErr) << 2; // we will want (2*error)^2
+    }
+}
+void tk2calo_sumtk(TkObj track[NTRACK], int tkerr2[NTRACK], ap_uint<NCALO> calo_track_link_bit[NTRACK], pt_t sumtk[NCALO], int sumtkerr2[NCALO]) {
+    for (int icalo = 0; icalo < NCALO; ++icalo) {
+        pt_t sum = 0;
+        int sumerr = 0;
+        for (int it = 0; it < NTRACK; ++it) {
+            if (calo_track_link_bit[it][icalo]) { sum += track[it].hwPt; sumerr += tkerr2[it]; }
+        }
+        sumtk[icalo] = sum;
+        sumtkerr2[icalo] = sumerr;
+    }
+}
+void tk2em_sumtk(TkObj track[NTRACK], ap_uint<NEMCALO> calo_track_link_bit[NTRACK], pt_t sumtk[NEMCALO]) {
+    for (int icalo = 0; icalo < NEMCALO; ++icalo) {
+        pt_t sum = 0;
+        for (int it = 0; it < NTRACK; ++it) {
+            if (calo_track_link_bit[it][icalo]) { sum += track[it].hwPt; }
+        }
+        sumtk[icalo] = sum;
+    }
+}
+
+
+void tk2calo_tkalgo(TkObj track[NTRACK], ap_uint<NCALO> calo_track_link_bit[NTRACK], PFChargedObj pfout[NTRACK]) {
+    const pt_t TKPT_MAX = 80; // 20 * PT_SCALE;
+    for (int it = 0; it < NTRACK; ++it) {
+        bool good = (track[it].hwPt < TKPT_MAX) || calo_track_link_bit[it].or_reduce();
+        if (good) {
+            pfout[it].hwPt  = track[it].hwPt;
+            pfout[it].hwEta = track[it].hwEta;
+            pfout[it].hwPhi = track[it].hwPhi;
+            pfout[it].hwId  = PID_Charged;
+            pfout[it].hwZ0  = track[it].hwZ0;
+        } else {
+            pfout[it].hwPt  = 0;
+            pfout[it].hwEta = 0;
+            pfout[it].hwPhi = 0;
+            pfout[it].hwId  = 0;
+            pfout[it].hwZ0  = 0;
+        }
+    }
+}
+
+void tk2calo_caloalgo(HadCaloObj calo[NCALO], pt_t sumtk[NCALO], int sumtkerr2[NCALO], PFNeutralObj pfout[NCALO]) {
+    for (int icalo = 0; icalo < NCALO; ++icalo) {
+        pt_t calopt;
+        if (sumtk[icalo] == 0) {
+            calopt = calo[icalo].hwPt;
+        } else {
+            pt_t ptdiff = calo[icalo].hwPt - sumtk[icalo];
+            if (ptdiff > 0 && (ptdiff*ptdiff) > sumtkerr2[icalo]) {
+                calopt = ptdiff;
+            } else {
+                calopt = 0;
+            }
+        }
+        pfout[icalo].hwPt  = calopt;
+        pfout[icalo].hwEta = calopt ? calo[icalo].hwEta : etaphi_t(0);
+        pfout[icalo].hwPhi = calopt ? calo[icalo].hwPhi : etaphi_t(0);
+        pfout[icalo].hwId  = calopt ? PID_Neutral : 0;
+    }
+}
+void tk2em_emalgo(EmCaloObj calo[NEMCALO], pt_t sumtk[NEMCALO], bool isEM[NEMCALO], pt_t photonPt[NEMCALO]) {
+    for (int icalo = 0; icalo < NEMCALO; ++icalo) {
+        if (sumtk[icalo] == 0) {
+            isEM[icalo] = true;
+            photonPt[icalo] = calo[icalo].hwPt;
+        } else {
+            pt_t ptdiff = calo[icalo].hwPt - sumtk[icalo];
+            if (ptdiff*ptdiff <= ((calo[icalo].hwPtErr*calo[icalo].hwPtErr)<<2)) {
+                photonPt[icalo] = 0;    
+                isEM[icalo] = true;
+            } else if (ptdiff > 0) {
+                photonPt[icalo] = ptdiff;    
+                isEM[icalo] = true;
+            } else {
+                photonPt[icalo] = 0;    
+                isEM[icalo] = false;
+            }
+        }
+    }
+}
+void tk2em_elealgo(ap_uint<NEMCALO> em_track_link_bit[NTRACK], bool isEM[NEMCALO], bool isEle[NTRACK]) {
+    for (int it = 0; it < NTRACK; ++it) {
+        bool ele = false;
+        for (int icalo = 0; icalo < NEMCALO; ++icalo) { 
+            if (isEM[icalo] && em_track_link_bit[it][icalo]) ele = true;
+        }
+        isEle[it] = ele;
+    }
+}
+void tk2em_photons(EmCaloObj calo[NEMCALO], pt_t photonPt[NEMCALO], PFNeutralObj pfout[NSELCALO]) {
+    for (int icalo = 0; icalo < NEMCALO; ++icalo) {
+        pfout[icalo].hwPt  = photonPt[icalo];
+        pfout[icalo].hwEta = photonPt[icalo] ? calo[icalo].hwEta : etaphi_t(0);
+        pfout[icalo].hwPhi = photonPt[icalo] ? calo[icalo].hwPhi : etaphi_t(0);
+        pfout[icalo].hwId  = photonPt[icalo] ? PID_Photon : 0;
+    }
+}
+
+
+void tk2calo_algo(HadCaloObj calo[NCALO], TkObj track[NTRACK], PFChargedObj outch[NTRACK], PFNeutralObj outne[NSELCALO]) {
+    #pragma HLS ARRAY_PARTITION variable=calo complete
+    #pragma HLS ARRAY_PARTITION variable=track complete
+    #pragma HLS ARRAY_PARTITION variable=outch complete
+    #pragma HLS ARRAY_PARTITION variable=outne complete
+
+    #pragma HLS pipeline II=5
+
+    ap_uint<NCALO> calo_track_link_bit[NTRACK];
+    #pragma HLS ARRAY_PARTITION variable=calo_track_link_bit complete
+    tk2calo_link(calo, track, calo_track_link_bit);
+
+    int tkerr2[NTRACK];
+    #pragma HLS ARRAY_PARTITION variable=tkerr2 complete
+    tk2calo_tkerr2(track, tkerr2);
+
+    pt_t sumtk[NCALO]; int sumtkerr2[NCALO];
+    #pragma HLS ARRAY_PARTITION variable=sumtk complete
+        #pragma HLS ARRAY_PARTITION variable=sumtkerr2 complete
+
+    tk2calo_tkalgo(track, calo_track_link_bit, outch);
+    tk2calo_sumtk(track, tkerr2, calo_track_link_bit, sumtk, sumtkerr2);
+
+    PFNeutralObj outne_all[NCALO];
+    #pragma HLS ARRAY_PARTITION variable=outne_all complete
+    tk2calo_caloalgo(calo, sumtk, sumtkerr2, outne_all);
+    ptsort_hwopt<PFNeutralObj,NCALO,NSELCALO>(outne_all, outne);
+}
+
+void tk2em_step1(EmCaloObj calo[NEMCALO], TkObj track[NTRACK], bool isEle[NTRACK], PFNeutralObj outpho[NPHOTON]) {
+    #pragma HLS ARRAY_PARTITION variable=calo complete
+    #pragma HLS ARRAY_PARTITION variable=track complete
+    #pragma HLS ARRAY_PARTITION variable=isEle complete
+    #pragma HLS ARRAY_PARTITION variable=isEM complete
+    #pragma HLS ARRAY_PARTITION variable=outpho complete
+
+    #pragma HLS pipeline II=5
+
+    ap_uint<NEMCALO> em_track_link_bit[NTRACK];
+    #pragma HLS ARRAY_PARTITION variable=em_track_link_bit complete
+    tk2em_link(calo, track, em_track_link_bit);
+
+    pt_t sumtk[NEMCALO]; 
+    #pragma HLS ARRAY_PARTITION variable=sumtk complete
+
+    pt_t photonPt[NEMCALO];
+    #pragma HLS ARRAY_PARTITION variable=photonPt complete
+
+    bool isEM[NEMCALO];
+    #pragma HLS ARRAY_PARTITION variable=isEM complete
+
+    tk2em_sumtk(track, em_track_link_bit, sumtk);
+    tk2em_emalgo(calo, sumtk, isEM, photonPt);
+    tk2em_photons(calo, photonPt, outpho);
+    tk2em_elealgo(em_track_link_bit, isEM, isEle);
+}
+
+
+

--- a/src/simple_pfalgo3.h
+++ b/src/simple_pfalgo3.h
@@ -8,10 +8,17 @@ etaphi_t dr_box(etaphi_t eta1, etaphi_t phi1, etaphi_t eta2, etaphi_t phi2) ;
 int dr2_int(etaphi_t eta1, etaphi_t phi1, etaphi_t eta2, etaphi_t phi2) ;
 template<int NB> ap_uint<NB>  dr2_int_cap(etaphi_t eta1, etaphi_t phi1, etaphi_t eta2, etaphi_t phi2, ap_uint<NB> max) ;
 
-void pfalgo3_ref(HadCaloObj calo[NCALO], TkObj track[NTRACK], PFChargedObj outch[NTRACK], PFNeutralObj outne[NSELCALO]) ;
-void tk2calo_algo(HadCaloObj calo[NCALO], TkObj track[NTRACK], PFChargedObj outch[NTRACK], PFNeutralObj outne[NSELCALO]) ;
-void tk2em_step1_ref(EmCaloObj emcalo[NEMCALO], TkObj track[NTRACK], bool isEle[NTRACK], PFNeutralObj outpho[NPHOTON]) ;
-void tk2em_step1(EmCaloObj emcalo[NEMCALO], TkObj track[NTRACK], bool isEle[NTRACK], PFNeutralObj outpho[NPHOTON]) ;
+void pfalgo3_calo_ref(HadCaloObj calo[NCALO], TkObj track[NTRACK], PFChargedObj outch[NTRACK], PFNeutralObj outne[NSELCALO]) ;
+void pfalgo3_calo(HadCaloObj calo[NCALO], TkObj track[NTRACK], PFChargedObj outch[NTRACK], PFNeutralObj outne[NSELCALO]) ;
+void pfalgo3_em_ref(EmCaloObj emcalo[NEMCALO], HadCaloObj hadcalo[NCALO], TkObj track[NTRACK], bool isEle[NTRACK], PFNeutralObj outpho[NPHOTON], HadCaloObj hadcalo_out[NCALO]) ;
+void pfalgo3_em(EmCaloObj emcalo[NEMCALO], HadCaloObj hadcalo[NCALO], TkObj track[NTRACK], bool isEle[NTRACK], PFNeutralObj outpho[NPHOTON], HadCaloObj hadcalo_out[NCALO]) ;
+void pfalgo3_full_ref(EmCaloObj emcalo[NEMCALO], HadCaloObj hadcalo[NCALO], TkObj track[NTRACK], PFChargedObj outch[NTRACK], PFNeutralObj outpho[NPHOTON], PFNeutralObj outne[NSELCALO]) ;
+void pfalgo3_full(EmCaloObj emcalo[NEMCALO], HadCaloObj hadcalo[NCALO], TkObj track[NTRACK], PFChargedObj outch[NTRACK], PFNeutralObj outpho[NPHOTON], PFNeutralObj outne[NSELCALO]) ;
+
+#define PFALGO3_DR2MAX_TK_CALO 756
+#define PFALGO3_DR2MAX_EM_CALO 525
+#define PFALGO3_DR2MAX_TK_EM   84
+#define PFALGO3_TK_MAXINVPT    80
 
 template<typename T, int NIn, int NOut>
 void ptsort_hwopt(T in[NIn], T out[NOut]) {

--- a/src/simple_pfalgo3.h
+++ b/src/simple_pfalgo3.h
@@ -1,0 +1,43 @@
+#ifndef SIMPLE_PFALGO3_H
+#define SIMPLE_PFALGO3_H
+
+#include "data.h"
+
+bool match_box(etaphi_t eta1, etaphi_t phi1, etaphi_t eta2, etaphi_t phi2, etaphi_t boxSize) ;
+etaphi_t dr_box(etaphi_t eta1, etaphi_t phi1, etaphi_t eta2, etaphi_t phi2) ;
+int dr2_int(etaphi_t eta1, etaphi_t phi1, etaphi_t eta2, etaphi_t phi2) ;
+template<int NB> ap_uint<NB>  dr2_int_cap(etaphi_t eta1, etaphi_t phi1, etaphi_t eta2, etaphi_t phi2, ap_uint<NB> max) ;
+
+void pfalgo3_ref(HadCaloObj calo[NCALO], TkObj track[NTRACK], PFChargedObj outch[NTRACK], PFNeutralObj outne[NSELCALO]) ;
+void tk2calo_algo(HadCaloObj calo[NCALO], TkObj track[NTRACK], PFChargedObj outch[NTRACK], PFNeutralObj outne[NSELCALO]) ;
+void tk2em_step1_ref(EmCaloObj emcalo[NEMCALO], TkObj track[NTRACK], bool isEle[NTRACK], PFNeutralObj outpho[NPHOTON]) ;
+void tk2em_step1(EmCaloObj emcalo[NEMCALO], TkObj track[NTRACK], bool isEle[NTRACK], PFNeutralObj outpho[NPHOTON]) ;
+
+template<typename T, int NIn, int NOut>
+void ptsort_hwopt(T in[NIn], T out[NOut]) {
+    T tmp[NOut];
+    #pragma HLS ARRAY_PARTITION variable=tmp complete
+
+    for (int iout = 0; iout < NOut; ++iout) {
+        #pragma HLS unroll
+        tmp[iout].hwPt = 0;
+    }
+
+    for (int it = 0; it < NIn; ++it) {
+        for (int iout = NOut-1; iout >= 0; --iout) {
+            if (tmp[iout].hwPt <= in[it].hwPt) {
+                if (iout == 0 || tmp[iout-1].hwPt > in[it].hwPt) {
+                    tmp[iout] = in[it];
+                } else {
+                    tmp[iout] = tmp[iout-1];
+                }
+            }
+        }
+
+    }
+    for (int iout = 0; iout < NOut; ++iout) {
+        out[iout] = tmp[iout];
+    }
+
+}
+#endif


### PR DESCRIPTION
 * Missing muons
 * Few simplifications:
   * tk to calo match sorting is still by plain deltaR, without the delta(pT) part
   * track-calo compatibility is a symmetric 2 sigma, not 2 sigma low / 1.2 sigma high
   * all unlinked tracks get the same pt cut independently of quality
   * electrons always get their pt from the track

Not optimized yet the HLS synthesis

````
================================================================
== Vivado HLS Report for 'pfalgo3_full'
================================================================
* Date:           Mon Jun 19 19:00:07 2017

* Version:        2017.1 (Build 1846317 on Fri Apr 14 19:19:38 MDT 2017)
* Project:        proj2
* Solution:       solution1
* Product family: kintexu
* Target device:  xcku115-flvf1924-2-i


================================================================
== Performance Estimates
================================================================
+ Timing (ns):
    * Summary:
    +--------+-------+----------+------------+
    |  Clock | Target| Estimated| Uncertainty|
    +--------+-------+----------+------------+
    |ap_clk  |   5.00|      4.38|        0.62|
    +--------+-------+----------+------------+

+ Latency (clock cycles):
    * Summary:
    +-----+-----+-----+-----+----------+
    |  Latency  |  Interval | Pipeline |
    | min | max | min | max |   Type   |
    +-----+-----+-----+-----+----------+
    |   47|   47|    5|    5| function |
    +-----+-----+-----+-----+----------+

    + Detail:
        * Instance:
        +-----------------------------------+------------------+-----+-----+-----+-----+----------+
        |                                   |                  |  Latency  |  Interval | Pipeline |
        |              Instance             |      Module      | min | max | min | max |   Type   |
        +-----------------------------------+------------------+-----+-----+-----+-----+----------+
        |grp_tk2calo_link_fu_2738           |tk2calo_link      |    7|    7|    5|    5| function |
        |grp_em2calo_link_fu_2826           |em2calo_link      |    7|    7|    5|    5| function |
        |grp_tk2em_link_fu_2902             |tk2em_link        |    7|    7|    5|    5| function |
        |grp_tk2calo_sumtk_fu_3002          |tk2calo_sumtk     |    5|    5|    5|    5| function |
        |grp_em2calo_sumem_fu_3054          |em2calo_sumem     |    5|    5|    5|    5| function |
        |grp_tk2em_sumtk_fu_3094            |tk2em_sumtk       |    5|    5|    5|    5| function |
        |grp_ptsort_hwopt_fu_3122           |ptsort_hwopt      |    2|    2|    3|    3| function |
        |grp_tk2calo_caloalgo_fu_3174       |tk2calo_caloalgo  |    5|    5|    5|    5| function |
        |grp_tk2em_emalgo_fu_3238           |tk2em_emalgo      |    5|    5|    5|    5| function |
        |call_ret1_em2calo_sub_fu_3278      |em2calo_sub       |    0|    0|    1|    1| function |
        |call_ret10_tk2calo_tkalgo_fu_3354  |tk2calo_tkalgo    |    0|    0|    1|    1| function |
        |call_ret7_tk2em_elealgo_fu_3430    |tk2em_elealgo     |    0|    0|    1|    1| function |
        |call_ret6_tk2em_photons_fu_3458    |tk2em_photons     |    0|    0|    1|    1| function |
        +-----------------------------------+------------------+-----+-----+-----+-----+----------+

        * Loop:
        N/A



================================================================
== Utilization Estimates
================================================================
* Summary:
+---------------------+---------+-------+---------+--------+
|         Name        | BRAM_18K| DSP48E|    FF   |   LUT  |
+---------------------+---------+-------+---------+--------+
|DSP                  |        -|     12|        -|       -|
|Expression           |        -|      -|        0|       4|
|FIFO                 |        -|      -|        -|       -|
|Instance             |        -|     36|    37298|  117412|
|Memory               |        -|      -|        -|       -|
|Multiplexer          |        -|      -|        -|      60|
|Register             |        -|      -|    20411|    7520|
+---------------------+---------+-------+---------+--------+
|Total                |        0|     48|    57709|  124996|
+---------------------+---------+-------+---------+--------+
|Available SLR        |     2160|   2760|   663360|  331680|
+---------------------+---------+-------+---------+--------+
|Utilization SLR (%)  |        0|      1|        8|      37|
+---------------------+---------+-------+---------+--------+
|Available            |     4320|   5520|  1326720|  663360|
+---------------------+---------+-------+---------+--------+
|Utilization (%)      |        0|   ~0  |        4|      18|
+---------------------+---------+-------+---------+--------+
````