### PR TITLE
Firmware fixes & improvements targeting the MP7

### DIFF
--- a/firmware/simple_fullpfalgo.cpp
+++ b/firmware/simple_fullpfalgo.cpp
@@ -427,7 +427,7 @@ void pfalgo3_full(EmCaloObj calo[NEMCALO], HadCaloObj hadcalo[NCALO], TkObj trac
     #pragma HLS ARRAY_PARTITION variable=outne complete
     #pragma HLS ARRAY_PARTITION variable=outmu complete
 
-    #pragma HLS pipeline II=6
+    #pragma HLS pipeline II=HLS_pipeline_II
 
     // ---------------------------------------------------------------
     // TK-MU Linking
@@ -643,7 +643,7 @@ void mp7wrapped_pfalgo3_full(MP7DataWord input[MP7_NCHANN], MP7DataWord output[M
     #pragma HLS ARRAY_PARTITION variable=output complete
     #pragma HLS INTERFACE ap_none port=output
 
-    #pragma HLS pipeline II=6
+    #pragma HLS pipeline II=HLS_pipeline_II
 
     EmCaloObj emcalo[NEMCALO]; HadCaloObj hadcalo[NCALO]; TkObj track[NTRACK]; MuObj mu[NMU];
     #pragma HLS ARRAY_PARTITION variable=emcalo complete

--- a/pattern_serializer.cpp
+++ b/pattern_serializer.cpp
@@ -1,8 +1,8 @@
 #include "pattern_serializer.h"
 #include <cassert>
 
-MP7PatternSerializer::MP7PatternSerializer(const std::string &fname, unsigned int nmux, const std::string &boardName) :
-    fname_(fname), nmux_(nmux), nchann_(MP7_NCHANN/nmux), file_(nullptr), ipattern_(0) 
+MP7PatternSerializer::MP7PatternSerializer(const std::string &fname, unsigned int nmux, unsigned int nempty, const std::string &boardName) :
+    fname_(fname), nmux_(nmux), nchann_(MP7_NCHANN/nmux), nempty_(nempty), file_(nullptr), ipattern_(0) 
 {
     if (!fname.empty()) {
         file_ = fopen(fname.c_str(), "w");
@@ -32,6 +32,15 @@ void MP7PatternSerializer::operator()(const MP7DataWord event[MP7_NCHANN])
     if (nmux_ == 1) print(ipattern_, event);
     else push(event);
     ipattern_++;
+    if (nempty_ > 0) {
+        MP7DataWord zero_event[MP7_NCHANN];
+        for (unsigned int j = 0; j < MP7_NCHANN; ++j) zero_event[j] = 0;
+        for (unsigned int iempty = 0; iempty < nempty_; ++iempty) {
+            if (nmux_ == 1) print(ipattern_, zero_event);
+            else push(zero_event);
+            ipattern_++;
+        }
+    }
 }
 template<typename T> void MP7PatternSerializer::print(unsigned int iframe, const T & event) 
 //void MP7PatternSerializer::print(const MP7DataWord event[MP7_NCHANN]) 

--- a/pattern_serializer.cpp
+++ b/pattern_serializer.cpp
@@ -1,8 +1,8 @@
 #include "pattern_serializer.h"
 #include <cassert>
 
-MP7PatternSerializer::MP7PatternSerializer(const std::string &fname, unsigned int nmux, unsigned int nempty, const std::string &boardName) :
-    fname_(fname), nmux_(nmux), nchann_(MP7_NCHANN/nmux), nempty_(nempty), file_(nullptr), ipattern_(0) 
+MP7PatternSerializer::MP7PatternSerializer(const std::string &fname, unsigned int nmux, int nempty, const std::string &boardName) :
+    fname_(fname), nmux_(nmux), nchann_(MP7_NCHANN/nmux), nempty_(std::abs(nempty)), fillmagic_(nempty<0), file_(nullptr), ipattern_(0) 
 {
     if (!fname.empty()) {
         file_ = fopen(fname.c_str(), "w");
@@ -36,6 +36,9 @@ void MP7PatternSerializer::operator()(const MP7DataWord event[MP7_NCHANN])
         MP7DataWord zero_event[MP7_NCHANN];
         for (unsigned int j = 0; j < MP7_NCHANN; ++j) zero_event[j] = 0;
         for (unsigned int iempty = 0; iempty < nempty_; ++iempty) {
+            if (fillmagic_) {
+                for (unsigned int j = 0; j < MP7_NCHANN; ++j) zero_event[j] = ((ipattern_ << 16) & 0xFFFF0000) | ((iempty << 8) & 0xFF00) | (j & 0xFF);
+            }
             if (nmux_ == 1) print(ipattern_, zero_event);
             else push(zero_event);
             ipattern_++;
@@ -54,8 +57,8 @@ template<typename T> void MP7PatternSerializer::print(unsigned int iframe, const
 void MP7PatternSerializer::push(const MP7DataWord event[MP7_NCHANN])
 {
     int imux = (ipattern_ % nmux_), offs = imux * nchann_;
-    for (unsigned int im = 0, i = 0; im < nmux_; ++im) {
-        for (unsigned int ic = 0; ic < nchann_; ++ic, ++i) {
+    for (unsigned int ic = 0, i = 0; ic < nchann_; ++ic) {
+        for (unsigned int im = 0; im < nmux_; ++im, ++i) {
             buffer_[im][offs+ic] = event[i];
         }
     }

--- a/pattern_serializer.h
+++ b/pattern_serializer.h
@@ -7,13 +7,16 @@ class MP7PatternSerializer {
         /** 
             if nmux > 1, we assume that each event is sent in nmux clock cycles using nchann = MP7_NCHANN/nmux channels.
             there is no time offsetting in the inputs, i.e. the first nmux events all start at clock 0 end end at clock nmux-1
-              at clock = 0,      channel[ 0      ...   nchann-1 ] = first nchann words of region (or event) 1
-              at clock = 0,      channel[ nchann ... 2*nchann-1 ] = first nchann words of region (or event) 2
-              at clock = 0,      channel .....
-              at clock = 1,      channel[ 0      ...   nchann-1 ] = second nchann words of region (or event) 1
-              at clock = 1,      channel[ nchann ... 2*nchann-1 ] = second nchann words of region (or event) 2
-              at clock = 1,      channel .....
-              at clock = nmux-1, channel[ 0      ...   nchann-1 ] = last nchann words of region (or event) 1
+            data is sent by column, i.e. the first tmux words are sent on the first fiber in tmux clock cycles
+            suppose tmux = 4 and event[i] = [ w0[i] w1[i] ... w71[i] ]
+            then    payload[t = 0] = [ w0[0] w4[0] ... w64[0] w68[0]    w0[1] w4[1] ... w64[1] w68[1]    w0[2] ... w68[2]     w0[3] ... w68[3] ]
+                    payload[t = 1] = [ w1[0] w5[0] ... w65[0] w69[0]    w1[1] w5[1] ... w65[1] w69[1]    w1[2] ... w69[2]     w0[3] ... w69[3] ]
+                    payload[t = 2] = [ w2[0] w6[0] ... w66[0] w70[0]    w2[1] w6[1] ... w66[1] w70[1]    w2[2] ... w70[2]     w0[3] ... w70[3] ]
+                    payload[t = 3] = [ w3[0] w7[0] ... w67[0] w71[0]    w3[1] w7[1] ... w67[1] w71[1]    w3[2] ... w71[2]     w0[3] ... w71[3] ]
+                    payload[t = 0] = [ w0[4] w4[4] ... w64[4] w68[4]    w0[5] w4[5] ... w64[5] w68[5]    w0[6] ... w68[6]     w0[7] ... w68[7] ]
+                    payload[t = 1] = [ w1[4] w5[4] ... w65[4] w69[4]    w1[5] w5[5] ... w65[5] w69[5]    w1[6] ... w69[6]     w0[7] ... w69[7] ]
+                    payload[t = 2] = [ w2[4] w6[4] ... w66[4] w70[4]    w2[5] w6[5] ... w66[5] w70[5]    w2[6] ... w70[6]     w0[7] ... w70[7] ]
+                    payload[t = 3] = [ w3[4] w7[4] ... w67[4] w71[4]    w3[5] w7[5] ... w67[5] w71[5]    w3[6] ... w71[6]     w0[7] ... w71[7] ]
 
             if nempty > 0, put more N frames of empty events in the pattern file in between each good event.
             e.g. nempty = 1, nmux = 1 will give
@@ -27,9 +30,10 @@ class MP7PatternSerializer {
                   | event 2 (part 1)...   zero .... |
                   | event 2 (part 2)...   zero .... |
 
+            if nempty < 0, will do like nempty > 0 but filling with "magic" data instead of zeros
 
         */
-        MP7PatternSerializer(const std::string &fname, unsigned int nmux=1, unsigned int nempty=0, const std::string &boardName = "Board MP7_L1PF") ;
+        MP7PatternSerializer(const std::string &fname, unsigned int nmux=1, int nempty=0, const std::string &boardName = "Board MP7_L1PF") ;
         ~MP7PatternSerializer() ;
         
         void operator()(const MP7DataWord event[MP7_NCHANN]) ;
@@ -37,6 +41,7 @@ class MP7PatternSerializer {
     protected:
         const std::string fname_;
         const unsigned int nmux_, nchann_, nempty_;
+        const bool fillmagic_;
         FILE *file_;
         unsigned int ipattern_;
         class Pattern {

--- a/pattern_serializer.h
+++ b/pattern_serializer.h
@@ -14,15 +14,29 @@ class MP7PatternSerializer {
               at clock = 1,      channel[ nchann ... 2*nchann-1 ] = second nchann words of region (or event) 2
               at clock = 1,      channel .....
               at clock = nmux-1, channel[ 0      ...   nchann-1 ] = last nchann words of region (or event) 1
+
+            if nempty > 0, put more N frames of empty events in the pattern file in between each good event.
+            e.g. nempty = 1, nmux = 1 will give
+                  | event 1 ......    |
+                  | zeros             |
+                  | event 2 ......    |
+                  | zeros             |
+            while nempty = 1, nmux = 2 will give
+                  | event 1 (part 1)...   zero .... |
+                  | event 1 (part 2)...   zero .... |
+                  | event 2 (part 1)...   zero .... |
+                  | event 2 (part 2)...   zero .... |
+
+
         */
-        MP7PatternSerializer(const std::string &fname, unsigned int nmux=1, const std::string &boardName = "Board MP7_L1PF") ;
+        MP7PatternSerializer(const std::string &fname, unsigned int nmux=1, unsigned int nempty=0, const std::string &boardName = "Board MP7_L1PF") ;
         ~MP7PatternSerializer() ;
         
         void operator()(const MP7DataWord event[MP7_NCHANN]) ;
         
     protected:
         const std::string fname_;
-        const unsigned int nmux_, nchann_;
+        const unsigned int nmux_, nchann_, nempty_;
         FILE *file_;
         unsigned int ipattern_;
         class Pattern {

--- a/run_hls_fullpfalgo.tcl
+++ b/run_hls_fullpfalgo.tcl
@@ -7,7 +7,7 @@
 # open the project, don't forget to reset
 open_project -reset proj_fullpfalgo_15151504_240MHz_II6
 set_top pfalgo3_full
-add_files firmware/simple_fullpfalgo.cpp
+add_files firmware/simple_fullpfalgo.cpp "-DHLS_pipeline_II=6"
 add_files -tb simple_fullpfalgo_test.cpp
 add_files -tb simple_fullpfalgo_ref.cpp
 add_files -tb pattern_serializer.cpp

--- a/run_hls_fullpfalgo_mp7.tcl
+++ b/run_hls_fullpfalgo_mp7.tcl
@@ -2,10 +2,10 @@
 source config_hls_fullpfalgo_mp7.tcl
 
 # open the project, don't forget to reset
-open_project -reset "proj3-mp7-fast"
+open_project -reset "proj3-mp7-full"
 set_top ${l1pfTopFunc}
-add_files firmware/simple_fullpfalgo.cpp -cflags "-DTESTMP7"
-add_files -tb simple_fullpfalgo_test.cpp  -cflags "-DTESTMP7 -DMP7_TOP_FUNC=${l1pfTopFunc} -DMP7_REF_FUNC=${l1pfRefFunc} -DMP7_VALIDATE=${l1pfValidate}"
+add_files firmware/simple_fullpfalgo.cpp -cflags "-DTESTMP7 -DHLS_pipeline_II=2"
+add_files -tb simple_fullpfalgo_test.cpp  -cflags "-DTESTMP7 -DHLS_pipeline_II=2 -DMP7_TOP_FUNC=${l1pfTopFunc} -DMP7_REF_FUNC=${l1pfRefFunc} -DMP7_VALIDATE=${l1pfValidate}"
 add_files -tb simple_fullpfalgo_ref.cpp -cflags "-DTESTMP7"
 add_files -tb pattern_serializer.cpp -cflags "-DTESTMP7"
 add_files -tb DiscretePFInputs.h    -cflags "-DTESTMP7 -std=c++0x"

--- a/simple_fullpfalgo_test.cpp
+++ b/simple_fullpfalgo_test.cpp
@@ -71,7 +71,9 @@ int main() {
     PFNeutralObj outne[NSELCALO], outne_ref[NSELCALO];
     PFChargedObj outmupf[NMU], outmupf_ref[NMU];
 #if defined(TESTMP7)
-    MP7PatternSerializer serInPatterns("mp7_input_patterns.txt"), serOutPatterns("mp7_output_patterns.txt");
+    MP7PatternSerializer serInPatterns( "mp7_input_patterns.txt", HLS_pipeline_II,HLS_pipeline_II-1); // mux each event into HLS_pipeline_II frames
+    MP7PatternSerializer serOutPatterns("mp7_output_patterns.txt",HLS_pipeline_II,HLS_pipeline_II-1); // assume only one PF core running per chip,
+                                                                                                      // fill the rest of the lines with empty events for now
 #endif
     HumanReadablePatternSerializer serHR("human_readable_patterns.txt");
     HumanReadablePatternSerializer debugHR("-"); // this will print on stdout, we'll use it for errors

--- a/simple_fullpfalgo_test.cpp
+++ b/simple_fullpfalgo_test.cpp
@@ -4,7 +4,7 @@
 #include "DiscretePFInputs_IO.h"
 #include "pattern_serializer.h"
 
-#define NTEST 100
+#define NTEST 500
 
 bool had_equals(const HadCaloObj &out_ref, const HadCaloObj &out, const char *what, int idx) {
     bool ret;
@@ -73,6 +73,10 @@ int main() {
 #if defined(TESTMP7)
     MP7PatternSerializer serInPatterns( "mp7_input_patterns.txt", HLS_pipeline_II,HLS_pipeline_II-1); // mux each event into HLS_pipeline_II frames
     MP7PatternSerializer serOutPatterns("mp7_output_patterns.txt",HLS_pipeline_II,HLS_pipeline_II-1); // assume only one PF core running per chip,
+    MP7PatternSerializer serInPatterns2( "mp7_input_patterns_magic.txt", HLS_pipeline_II,-HLS_pipeline_II+1); // mux each event into HLS_pipeline_II frames
+    MP7PatternSerializer serOutPatterns2("mp7_output_patterns_magic.txt",HLS_pipeline_II,-HLS_pipeline_II+1); // assume only one PF core running per chip,
+    MP7PatternSerializer serInPatterns3( "mp7_input_patterns_nomux.txt");  // 
+    MP7PatternSerializer serOutPatterns3("mp7_output_patterns_nomux.txt"); // ,
                                                                                                       // fill the rest of the lines with empty events for now
 #endif
     HumanReadablePatternSerializer serHR("human_readable_patterns.txt");
@@ -111,6 +115,8 @@ int main() {
 
         // write out patterns for MP7 board hardware or simulator test
         serInPatterns(data_in); serOutPatterns(data_out);
+        serInPatterns2(data_in); serOutPatterns2(data_out);
+        serInPatterns3(data_in); serOutPatterns3(data_out);
 
 #else // standard PFAlgo test without MP7 packing
         pfalgo3_full_ref(emcalo, calo, track, mu, outch_ref, outpho_ref, outne_ref, outmupf_ref);


### PR DESCRIPTION
 * make the pipeline II controllable from the TCL file via a define
 * change the way data is serialized when splitting one event into multiple frames: send data words "vertically", i.e. the first fiber sends the first N words of the event in N clock cycles, the second fiber sents words N+1 ... 2N in N clock cycles and so on (before, the first fiber was sending words 0, 72/N * 1, 72/N * 2, ...)
    * this is more realistic, since neighbouring words in the event frame correspond to related content, and so it makes sense to send them on the same fiber
    * this also improves the layout on the FPGA, since data from a single fiber gets de-serialized into contiguous ports of the IP core, instead of being sent to far away ports.
* pattern serializer can also insert empty frame or frames with magic numbers (to help check the serialization is behaving correctly, and the alignment of input and output frames)

@dinyar 