### PR TITLE
First implementation of linpuppi with 2 eta bins, for HGCal

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,16 +23,15 @@ The board used is set with `-DBOARD_(board)`, which drives the code used to seri
 
 * PFAlgo3 (i.e. using emcalo, hadcalo, tracks, muons) is implemented and tested but only in the Barrel region. &Delta;R cuts are synchronized with CMSSW, but other parameters have not been checked recently.
 * PFAlgo2HGC (i.e. using calo, tracks, muons) is implemented and tested but only in the HGCal region. &Delta;R cuts are synchronized with CMSSW, but other parameters have not been checked recently.
-* Linearized puppi inside the tracker coverage is implemented and tested only in the Barrel (the HGCal has parameters binned in eta, for which the firmware implementation is easy but still missing). Parameters are also synchronized with CMSSW
-* In the forward region outside tracker coverage, linearized puppi goes in one step from calo clusters to puppi candidates, and is implemented and tested for both HF and HGCalNoTK. Parameters are also synchronized with
-CMSSW.
+* Linearized puppi inside the tracker coverage is implemented and tested both in the Barrel and in the HGCal (where it has parameters split in 2 eta bins). Parameters are also synchronized with CMSSW
+* In the forward region outside tracker coverage, linearized puppi goes in one step from calo clusters to puppi candidates, and is implemented and tested for both HF and HGCalNoTK. Parameters are also synchronized with CMSSW.
 
 ## Pending items
 
 In random order:
 * Investigate whether we can define integer coordinates in a clever way to have 2&pi; be equal to a power of 2, so that the wrapping of &Delta;&phi; would happen automatically, and we could use global coordinates.
-* Implement Linearized Puppi with eta bins in the HGCal
 * Separate in the inputs the tracks regionized using calorimeter (eta, phi) - for PF - and the tracks regionized using vertex (eta, phi) - for Puppi.
 * Puppi implementation can probably be cleaned up using `ap_fixed` instead of bitshifts by hand
+* LinearPuppi firmware implementation with eta bins can probably be cleaned up
 * Introduce options to customize the pattern file layout depending on the board (now it can be done only by changing the options passed in the constructor in the testbench source)
 * Cleanup & resurrect the remaining elements of the TDR demonstrator (vertexing, regionizer, layer 2, ...)

--- a/firmware/data.h
+++ b/firmware/data.h
@@ -1,12 +1,7 @@
 #ifndef FIRMWARE_DATA_H
 #define FIRMWARE_DATA_H
 
-#ifndef CMSSW_GIT_HASH
-  #include <ap_int.h>
-#else
-  // until ap_int is in a CMSSW release we can use
-  #include "ap_int_fake.h"
-#endif
+#include <ap_int.h>
 
 typedef ap_int<16> pt_t;
 typedef ap_int<10>  etaphi_t;

--- a/puppi/firmware/linpuppi.h
+++ b/puppi/firmware/linpuppi.h
@@ -2,7 +2,11 @@
 #define FIRMWARE_LINPUPPI_H
 
 #include <cmath>
+#ifdef CMSSW_GIT_HASH
+#include "data.h"
+#else
 #include "../../firmware/data.h"
+#endif
 
 #if defined(PACKING_DATA_SIZE) && defined(PACKING_NCHANN)
 #include "../../firmware/l1pf_encoding.h"

--- a/puppi/firmware/linpuppi.h
+++ b/puppi/firmware/linpuppi.h
@@ -76,8 +76,39 @@ void linpuppi_set_debug(bool debug);
 //=================================================
 #elif defined(REG_HGCal) 
 
-#error "Not implemented"
+#define LINPUPPI_etaBins 2
+#define LINPUPPI_etaCut  0 // assuming the region spans [1.5,2.5] (or 1.25,2.75 with the overlaps), 
+                           // the cut is exactly at the region center (2.0), so it's at 0 in integer coordinates
+#define LINPUPPI_invertEta 0 // 0 if we're building the FW for the positive eta endcap.
+
+#define LINPUPPI_DR2MAX  4727 // 0.3 cone
+#define LINPUPPI_DR2MIN    84 // 0.04 cone
 #define LINPUPPI_dzCut     40
+#define LINPUPPI_ptMax    200 // 50.0/LINPUPPI_ptLSB 
+
+#define LINPUPPI_ptSlopeNe  0.3 
+#define LINPUPPI_ptSlopePh  0.4 
+#define LINPUPPI_ptZeroNe   5.0 
+#define LINPUPPI_ptZeroPh   3.0 
+#define LINPUPPI_alphaSlope 1.5 
+#define LINPUPPI_alphaZero  6.0 
+#define LINPUPPI_alphaCrop  3.0 
+#define LINPUPPI_priorNe    5.0 
+#define LINPUPPI_priorPh    1.5 
+
+#define LINPUPPI_ptSlopeNe_1  0.3 
+#define LINPUPPI_ptSlopePh_1  0.4 
+#define LINPUPPI_ptZeroNe_1   7.0 
+#define LINPUPPI_ptZeroPh_1   4.0 
+#define LINPUPPI_alphaSlope_1 1.5 
+#define LINPUPPI_alphaZero_1  6.0 
+#define LINPUPPI_alphaCrop_1  3.0 
+#define LINPUPPI_priorNe_1    5.0 
+#define LINPUPPI_priorPh_1    1.5 
+
+
+#define LINPUPPI_ptCut        4 // 1.0/LINPUPPI_ptLSB
+#define LINPUPPI_ptCut_1      8 // 2.0/LINPUPPI_ptLSB
 
 //=================================================
 #elif defined(REG_HGCalNoTK)

--- a/puppi/linpuppi_ref.cpp
+++ b/puppi/linpuppi_ref.cpp
@@ -2,6 +2,41 @@
 #include <cmath>
 #include <algorithm>
 
+linpuppi_config::linpuppi_config(unsigned int nTrack_, unsigned int nIn_, unsigned int nOut_,
+                    unsigned int dR2Min_, unsigned int dR2Max_, unsigned int ptMax_, unsigned int dzCut_,
+                    int etaCut, bool invertEta,
+                    float ptSlopeNe_0, float ptSlopeNe_1, float ptSlopePh_0, float ptSlopePh_1, float ptZeroNe_0, float ptZeroNe_1, float ptZeroPh_0, float ptZeroPh_1, 
+                    float alphaSlope_0, float alphaSlope_1, float alphaZero_0, float alphaZero_1, float alphaCrop_0, float alphaCrop_1, 
+                    float priorNe_0, float priorNe_1, float priorPh_0, float priorPh_1, 
+                    unsigned int ptCut_0, unsigned int ptCut_1) :
+                nTrack(nTrack_), nIn(nIn_), nOut(nOut_),
+                dR2Min(dR2Min_), dR2Max(dR2Max_), ptMax(ptMax_), dzCut(dzCut_),
+                absEtaBins(1, etaCut), invertEtaBins(invertEta),
+                ptSlopeNe(2), ptSlopePh(2), ptZeroNe(2), ptZeroPh(2), alphaSlope(2), alphaZero(2), alphaCrop(2), priorNe(2), priorPh(2), 
+                ptCut(2) 
+{
+    ptSlopeNe[0] = ptSlopeNe_0; 
+    ptSlopeNe[1] = ptSlopeNe_1;
+    ptSlopePh[0] = ptSlopePh_0; 
+    ptSlopePh[1] = ptSlopePh_1;
+    ptZeroNe[0] = ptZeroNe_0; 
+    ptZeroNe[1] = ptZeroNe_1;
+    ptZeroPh[0] = ptZeroPh_0; 
+    ptZeroPh[1] = ptZeroPh_1;
+    alphaSlope[0] = alphaSlope_0; 
+    alphaSlope[1] = alphaSlope_1;
+    alphaZero[0] = alphaZero_0;
+    alphaZero[1] = alphaZero_1;
+    alphaCrop[0] = alphaCrop_0; 
+    alphaCrop[1] = alphaCrop_1;
+    priorNe[0] = priorNe_0; 
+    priorNe[1] = priorNe_1;
+    priorPh[0] = priorPh_0; 
+    priorPh[1] = priorPh_1;
+    ptCut[0] = ptCut_0; 
+    ptCut[1] = ptCut_1;
+}
+
 
 template<typename T>
 void puppisort_and_crop_ref(unsigned int nIn, unsigned int nOut, const T in[/*nIn*/], T out[/*nOut*/]) {
@@ -42,8 +77,11 @@ void linpuppi_chs_ref(const linpuppi_config &cfg, z0_t pvZ0, const PFChargedObj 
 }
 
 unsigned int linpuppi_ieta_ref(const linpuppi_config &cfg, etaphi_t eta) {
-    assert(cfg.absEtaBins.empty());
-    if (cfg.absEtaBins.empty()) return 0;
+    int n = cfg.absEtaBins.size();
+    for (int i = 0; i < n; ++i) {
+        if (int(eta) <= cfg.absEtaBins[i]) return (cfg.invertEtaBins ? n-i : i);
+    }
+    return cfg.invertEtaBins ? 0 : n;
 }
 
 pt_t linpuppi_ref_sum2puppiPt(const linpuppi_config &cfg, uint64_t sum, pt_t pt, unsigned int ieta, bool isEM, int icand, bool debug) {

--- a/puppi/linpuppi_ref.h
+++ b/puppi/linpuppi_ref.h
@@ -7,7 +7,7 @@
 struct linpuppi_config {
     unsigned int nTrack, nIn, nOut; // nIn, nOut refer to the calorimeter clusters or neutral PF candidates as input and as output (after sorting)
     unsigned int dR2Min, dR2Max, ptMax, dzCut;
-    std::vector<float> absEtaBins;
+    std::vector<int> absEtaBins; bool invertEtaBins;
     std::vector<float> ptSlopeNe, ptSlopePh, ptZeroNe, ptZeroPh;
     std::vector<float> alphaSlope, alphaZero, alphaCrop;
     std::vector<float> priorNe, priorPh;
@@ -21,20 +21,29 @@ struct linpuppi_config {
                     unsigned int ptCut_) :
                 nTrack(nTrack_), nIn(nIn_), nOut(nOut_),
                 dR2Min(dR2Min_), dR2Max(dR2Max_), ptMax(ptMax_), dzCut(dzCut_),
-                absEtaBins(),
+                absEtaBins(), invertEtaBins(false), 
                 ptSlopeNe(1, ptSlopeNe_), ptSlopePh(1, ptSlopePh_), ptZeroNe(1, ptZeroNe_), ptZeroPh(1, ptZeroPh_), alphaSlope(1, alphaSlope_), alphaZero(1, alphaZero_), alphaCrop(1, alphaCrop_), priorNe(1, priorNe_), priorPh(1, priorPh_), 
                 ptCut(1, ptCut_) {}
 
+     linpuppi_config(unsigned int nTrack_, unsigned int nIn_, unsigned int nOut_,
+                    unsigned int dR2Min_, unsigned int dR2Max_, unsigned int ptMax_, unsigned int dzCut_,
+                    int etaCut_, bool invertEtaBins_,
+                    float ptSlopeNe_0, float ptSlopeNe_1, float ptSlopePh_0, float ptSlopePh_1, float ptZeroNe_0, float ptZeroNe_1, float ptZeroPh_0, float ptZeroPh_1, 
+                    float alphaSlope_0, float alphaSlope_1, float alphaZero_0, float alphaZero_1, float alphaCrop_0, float alphaCrop_1, 
+                    float priorNe_0, float priorNe_1, float priorPh_0, float priorPh_1, 
+                    unsigned int ptCut_0, unsigned int ptCut_1) ;
+
+
     linpuppi_config(unsigned int nTrack_, unsigned int nIn_, unsigned int nOut_,
                     unsigned int dR2Min_, unsigned int dR2Max_, unsigned int ptMax_, unsigned int dzCut_,
-                    const std::vector<float> & absEtaBins_,
+                    const std::vector<int> & absEtaBins_, bool invertEtaBins_,
                     const std::vector<float> & ptSlopeNe_, const std::vector<float> & ptSlopePh_, const std::vector<float> & ptZeroNe_, const std::vector<float> & ptZeroPh_, 
                     const std::vector<float> & alphaSlope_, const std::vector<float> & alphaZero_, const std::vector<float> & alphaCrop_, 
                     const std::vector<float> & priorNe_, const std::vector<float> & priorPh_,
                     const std::vector<unsigned int> & ptCut_) :
                 nTrack(nTrack_), nIn(nIn_), nOut(nOut_),
                 dR2Min(dR2Min_), dR2Max(dR2Max_), ptMax(ptMax_), dzCut(dzCut_),
-                absEtaBins(),
+                absEtaBins(absEtaBins_), invertEtaBins(invertEtaBins_),
                 ptSlopeNe(ptSlopeNe_), ptSlopePh(ptSlopePh_), ptZeroNe(ptZeroNe_), ptZeroPh(ptZeroPh_), alphaSlope(alphaSlope_), alphaZero(alphaZero_), alphaCrop(alphaCrop_), priorNe(priorNe_), priorPh(priorPh_), 
                 ptCut(ptCut_) {}
 

--- a/puppi/linpuppi_ref.h
+++ b/puppi/linpuppi_ref.h
@@ -1,7 +1,11 @@
 #ifndef LINPUPPI_REF_H
 #define LINPUPPI_REF_H
 
-#include "firmware/linpuppi.h"
+#ifdef CMSSW_GIT_HASH
+  #include "../firmware/linpuppi.h"
+#else
+  #include "firmware/linpuppi.h"
+#endif
 #include <vector>
 
 struct linpuppi_config {
@@ -50,7 +54,7 @@ struct linpuppi_config {
 };
 
 // charged
-void linpuppi_chs_ref(const linpuppi_config &cfg, z0_t pvZ0, const PFChargedObj pfch[/*cfg.nTrack*/], PFChargedObj outallch[/*cfg.nTrack*/]) ;
+void linpuppi_chs_ref(const linpuppi_config &cfg, z0_t pvZ0, const PFChargedObj pfch[/*cfg.nTrack*/], PFChargedObj outallch[/*cfg.nTrack*/], bool debug) ;
 
 // neutrals, in the tracker
 void linpuppi_flt(const linpuppi_config &cfg, const TkObj track[/*cfg.nTrack*/], z0_t pvZ0, const PFNeutralObj pfallne[/*cfg.nIn*/], PFNeutralObj outallne_nocut[/*cfg.nIn*/], PFNeutralObj outallne[/*cfg.nIn*/], PFNeutralObj outselne[/*cfg.nOut*/], bool debug) ;

--- a/puppi/linpuppi_test.cpp
+++ b/puppi/linpuppi_test.cpp
@@ -111,7 +111,7 @@ int main() {
     #endif
 #endif
 
-        linpuppi_chs_ref(pucfg, hwZPV, pfch, outallch_ref);
+        linpuppi_chs_ref(pucfg, hwZPV, pfch, outallch_ref, verbose);
         linpuppi_ref(pucfg, track, hwZPV, pfallne, outallne_ref_nocut, outallne_ref, outselne_ref, verbose);
         linpuppi_flt(pucfg, track, hwZPV, pfallne, outallne_flt_nocut, outallne_flt, outselne_flt, verbose);
 

--- a/puppi/linpuppi_test.cpp
+++ b/puppi/linpuppi_test.cpp
@@ -33,6 +33,14 @@ int main() {
     pfalgo_config pfcfg(NTRACK,NCALO,NMU, NSELCALO,
                         PFALGO_DR2MAX_TK_MU, PFALGO_DR2MAX_TK_CALO,
                         PFALGO_TK_MAXINVPT_LOOSE, PFALGO_TK_MAXINVPT_TIGHT);
+    linpuppi_config pucfg(NTRACK, NALLNEUTRALS, NNEUTRALS,
+                          LINPUPPI_DR2MIN, LINPUPPI_DR2MAX, LINPUPPI_ptMax, LINPUPPI_dzCut,
+                          LINPUPPI_etaCut, LINPUPPI_invertEta,
+                          LINPUPPI_ptSlopeNe, LINPUPPI_ptSlopeNe_1, LINPUPPI_ptSlopePh, LINPUPPI_ptSlopePh_1, 
+                          LINPUPPI_ptZeroNe, LINPUPPI_ptZeroNe_1, LINPUPPI_ptZeroPh, LINPUPPI_ptZeroPh_1, 
+                          LINPUPPI_alphaSlope, LINPUPPI_alphaSlope_1, LINPUPPI_alphaZero, LINPUPPI_alphaZero_1, LINPUPPI_alphaCrop, LINPUPPI_alphaCrop_1, 
+                          LINPUPPI_priorNe, LINPUPPI_priorNe_1, LINPUPPI_priorPh, LINPUPPI_priorPh_1,
+                          LINPUPPI_ptCut, LINPUPPI_ptCut_1);
 #endif
     
     // input TP objects and PV
@@ -74,7 +82,7 @@ int main() {
         pfalgo3_ref(pfcfg, emcalo, hadcalo, track, mu, pfch, pfpho, pfne, pfmu);
         pfalgo3_merge_neutrals_ref(pfcfg, pfpho, pfne, pfallne);
 #elif defined(REG_HGCal)
-        pfalgo2hgc(pfcfg, hadcalo, track, mu, pfch, pfallne, pfmu); 
+        pfalgo2hgc_ref(pfcfg, hadcalo, track, mu, pfch, pfallne, pfmu); 
 #endif
 
         bool verbose = 0;

--- a/utils/DiscretePF2Firmware.h
+++ b/utils/DiscretePF2Firmware.h
@@ -9,7 +9,7 @@
 namespace dpf2fw {
 
     // convert inputs from discrete to firmware
-    void convert(const l1tpf_impl::PropagatedTrack & in, TkObj &out) {
+    inline void convert(const l1tpf_impl::PropagatedTrack & in, TkObj &out) {
         out.hwPt = in.hwPt;
         out.hwPtErr = in.hwCaloPtErr;
         out.hwEta = in.hwEta; // @calo
@@ -18,31 +18,60 @@ namespace dpf2fw {
         out.hwTightQuality = (in.hwStubs >= 6 && in.hwChi2 < 500);
     }
 
-    TkObj transformConvert(const l1tpf_impl::PropagatedTrack & in) {
+    inline TkObj transformConvert(const l1tpf_impl::PropagatedTrack & in) {
         TkObj out;
         convert(in, out);
         return out;
     }
 
-    void convert(const l1tpf_impl::CaloCluster & in, HadCaloObj & out) {
+    inline void convert(const l1tpf_impl::CaloCluster & in, HadCaloObj & out) {
         out.hwPt = in.hwPt;
         out.hwEmPt = in.hwEmPt;
         out.hwEta = in.hwEta;
         out.hwPhi = in.hwPhi;
         out.hwIsEM = in.isEM;
     }
-    void convert(const l1tpf_impl::CaloCluster & in, EmCaloObj & out) {
+    inline void convert(const l1tpf_impl::CaloCluster & in, EmCaloObj & out) {
         out.hwPt = in.hwPt;
         out.hwPtErr = in.hwPtErr;
         out.hwEta = in.hwEta;
         out.hwPhi = in.hwPhi;
     }
-    void convert(const l1tpf_impl::Muon & in, MuObj & out) {
+    inline void convert(const l1tpf_impl::Muon & in, MuObj & out) {
         out.hwPt = in.hwPt;
         out.hwPtErr = 0; // does not exist in input
         out.hwEta = in.hwEta; // @calo
         out.hwPhi = in.hwPhi; // @calo
     }
+
+    inline void convert(const l1tpf_impl::PFParticle &src, PFChargedObj & pf) {
+        pf.hwPt = src.hwPt;
+        pf.hwEta = src.hwEta;
+        pf.hwPhi = src.hwPhi;
+        switch(src.hwId) {
+            case 0: pf.hwId = PID_Charged; break;
+            case 1: pf.hwId = PID_Electron; break;
+            case 2: pf.hwId = PID_Neutral; break;
+            case 3: pf.hwId = PID_Photon; break;
+            case 4: pf.hwId = PID_Muon; break;
+        }
+        pf.hwZ0 = src.track.hwZ0;
+    }
+    inline void convert(const l1tpf_impl::PFParticle &src, PFNeutralObj & pf, bool isPuppi=false) {
+        pf.hwPt = src.hwPt;
+        pf.hwEta = src.hwEta;
+        pf.hwPhi = src.hwPhi;
+        switch(src.hwId) {
+            case 0: pf.hwId = PID_Charged; break;
+            case 1: pf.hwId = PID_Electron; break;
+            case 2: pf.hwId = PID_Neutral; break;
+            case 3: pf.hwId = PID_Photon; break;
+            case 4: pf.hwId = PID_Muon; break;
+        }
+        pf.hwPtPuppi = isPuppi ? pt_t(src.hwPt) : pt_t(0);
+    }
+
+
 
     template<unsigned int NMAX, typename In, typename Out>
     void convert(const std::vector<In> & in, Out out[NMAX]) {

--- a/utils/Firmware2DiscretePF.h
+++ b/utils/Firmware2DiscretePF.h
@@ -69,6 +69,13 @@ namespace fw2dpf {
         pf.hwStatus = 0;
         out.push_back(pf);
     }
+    inline void convert_puppi(const PFNeutralObj & src, std::vector<l1tpf_impl::PFParticle> &out) {
+        convert(src, out);
+        out.back().hwPt = src.hwPtPuppi;
+        out.back().setPuppiW(out.back().hwPt/float(src.hwPt));
+    }
+
+
 
     // convert inputs from discrete to firmware
     inline void convert(const TkObj & in, l1tpf_impl::PropagatedTrack & out) {
@@ -114,6 +121,12 @@ namespace fw2dpf {
             if (in[i].hwPt > 0) convert(in[i], out);
         }
     } 
+    inline void convert_puppi(unsigned int NMAX, const PFNeutralObj in[], std::vector<l1tpf_impl::PFParticle> &out) {
+        for (unsigned int i = 0; i < NMAX; ++i) {
+            if (in[i].hwPtPuppi > 0) convert_puppi(in[i], out);
+        }
+    } 
+
     template<unsigned int NMAX>
     void convert(const PFChargedObj in[NMAX], std::vector<l1tpf_impl::PropagatedTrack> srctracks, std::vector<l1tpf_impl::PFParticle> &out) {
         for (unsigned int i = 0; i < NMAX; ++i) {


### PR DESCRIPTION
First implementation of linpuppi with 2 eta bins, for HGCal.

For the default HGCal multiplicities (25 tracks, 20 calo, 4 mu, 15 selected calo), and synthethized for a VCU118 at 3ns clock and II=2, the linearized puppi has a latency of 31 clocks, and resource usage of 204 BRAM, 603 DSP, 153k FFs, 80k LUTs. 
These are for the linpuppiNoCrop function, i.e. without the packing/unpacking and the pt sorting & cropping at the end.
Compared to the barrel, resource usage is ~25% less due to less inputs, latency is 1 clock more than the barrel (maybe due to the extra logic to pick the eta bin)
