### PR TITLE
Add input track conversion block

### DIFF
--- a/converter/firmware/wrapper.cpp
+++ b/converter/firmware/wrapper.cpp
@@ -8,9 +8,6 @@ using std::cout;
 using std::endl;
 #endif
 
-// #include "../../submodules/GTT_MET_HLS/eta/src/eta_top.cc"
-// #include "../../submodules/GTT_MET_HLS/p_T/src/p_T_top.cc"
-
 void pf_input_track_conv_hw(input_t in, output_t& out){
     #pragma HLS pipeline II=1
 
@@ -42,17 +39,6 @@ void pf_input_track_conv_hw(input_t in, output_t& out){
 
     etaphi_t conv_eta;
     convert_eta(tanlam,conv_eta);
-
-    // in_pt_t conv_in_pt = rinv;
-    // out_pt_t conv_out_pt;
-    // p_T(conv_in_pt, &conv_out_pt);
-
-    // in_eta_t conv_in_eta = tanlam;
-    // out_eta_t conv_out_eta;
-    // bool parity=1;
-    // bool erase;
-    // eta(conv_in_eta, &conv_out_eta, parity, &erase);
-    // tanlam_t tan_lambda = (M_PI/2.)-(2.*atan(exp(-1.*track_in[i].floatEta())));
 
     // pack in PF format
     pt_t pf_pt = conv_pt;

--- a/converter/firmware/wrapper.cpp
+++ b/converter/firmware/wrapper.cpp
@@ -1,0 +1,261 @@
+/*
+HLS implementation of input conversion wrapper
+*/
+#include "wrapper.h"
+#ifndef __SYNTHESIS__
+#include <cstdio>
+using std::cout;
+using std::endl;
+#endif
+
+// #include "../../submodules/GTT_MET_HLS/eta/src/eta_top.cc"
+// #include "../../submodules/GTT_MET_HLS/p_T/src/p_T_top.cc"
+
+void pf_input_track_conv_hw(input_t in, output_t& out){
+    #pragma HLS pipeline II=1
+
+    // unpack L1Track format
+    rinv_t     rinv    ;
+    tkphi_t    tkphi   ;
+    tanlam_t   tanlam  ;
+    tkz0_t     tkz0    ;
+    tkd0_t     tkd0    ;
+    chi2rphi_t chi2rphi;
+    chi2rz_t   chi2rz  ;
+    bendChi2_t bendChi2;
+    hit_t      hit     ;
+    trackMVA_t trackMVA;
+    extraMVA_t extraMVA;
+    valid_t    valid   ;
+
+    unpack_L1T_track(in, rinv, tkphi, tanlam, tkz0, tkd0, chi2rphi, chi2rz, bendChi2, hit, trackMVA, extraMVA, valid);
+
+    // selection
+    if(!valid){
+        out=0;
+        return;
+    }
+
+    // converters
+    pt_t conv_pt;
+    convert_pt(rinv,conv_pt);
+
+    etaphi_t conv_eta;
+    convert_eta(tanlam,conv_eta);
+
+    // in_pt_t conv_in_pt = rinv;
+    // out_pt_t conv_out_pt;
+    // p_T(conv_in_pt, &conv_out_pt);
+
+    // in_eta_t conv_in_eta = tanlam;
+    // out_eta_t conv_out_eta;
+    // bool parity=1;
+    // bool erase;
+    // eta(conv_in_eta, &conv_out_eta, parity, &erase);
+    // tanlam_t tan_lambda = (M_PI/2.)-(2.*atan(exp(-1.*track_in[i].floatEta())));
+
+    // pack in PF format
+    pt_t pf_pt = conv_pt;
+    pt_t pf_pterr = conv_pt; // TODO
+    etaphi_t pf_eta = conv_eta;
+    etaphi_t pf_phi = bigfix_t(tkphi)*bigfix_t(PF_ETAPHI_SCALE);
+    z0_t pf_z0 = bigfix_t(tkz0)*bigfix_t(PF_Z0_SCALE);
+    bool pf_TightQuality = 1;
+    pack_pf_track(out, pf_pt, pf_pterr, pf_eta, pf_phi, pf_z0, pf_TightQuality);
+}
+
+void pack_L1T_track(ap_uint<kTrackWordSize> &tk,
+                    rinv_t     rinv    ,
+                    tkphi_t    tkphi   ,
+                    tanlam_t   tanlam  ,
+                    tkz0_t     tkz0    ,
+                    tkd0_t     tkd0    ,
+                    chi2rphi_t chi2rphi,
+                    chi2rz_t   chi2rz  ,
+                    bendChi2_t bendChi2,
+                    hit_t      hit     ,
+                    trackMVA_t trackMVA,
+                    extraMVA_t extraMVA,
+                    valid_t    valid   ){
+
+    ap_uint<rinv_t    ::width> word_rinv      = rinv    .range(rinv_t    ::width-1,0);
+    ap_uint<tkphi_t   ::width> word_tkphi     = tkphi   .range(tkphi_t   ::width-1,0);
+    ap_uint<tanlam_t  ::width> word_tanlam    = tanlam  .range(tanlam_t  ::width-1,0);
+    ap_uint<tkz0_t    ::width> word_tkz0      = tkz0    .range(tkz0_t    ::width-1,0);
+    ap_uint<tkd0_t    ::width> word_tkd0      = tkd0    .range(tkd0_t    ::width-1,0);
+    ap_uint<chi2rphi_t::width> word_chi2rphi  = chi2rphi.range(chi2rphi_t::width-1,0);
+    ap_uint<chi2rz_t  ::width> word_chi2rz    = chi2rz  .range(chi2rz_t  ::width-1,0);
+    ap_uint<bendChi2_t::width> word_bendChi2  = bendChi2.range(bendChi2_t::width-1,0);
+    ap_uint<hit_t     ::width> word_hit       = hit     .range(hit_t     ::width-1,0);
+    ap_uint<trackMVA_t::width> word_trackMVA  = trackMVA.range(trackMVA_t::width-1,0);
+    ap_uint<extraMVA_t::width> word_extraMVA  = extraMVA.range(extraMVA_t::width-1,0);
+    ap_uint<valid_t   ::width> word_valid     = valid   .range(valid_t   ::width-1,0);
+
+    tk = (word_valid, word_extraMVA, word_trackMVA, word_hit, word_bendChi2, word_chi2rz, 
+          word_chi2rphi, word_tkd0, word_tkz0, word_tanlam, word_tkphi, word_rinv);    
+}
+
+void unpack_L1T_track(ap_uint<kTrackWordSize> in,
+                    rinv_t     &rinv    ,
+                    tkphi_t    &tkphi   ,
+                    tanlam_t   &tanlam  ,
+                    tkz0_t     &tkz0    ,
+                    tkd0_t     &tkd0    ,
+                    chi2rphi_t &chi2rphi,
+                    chi2rz_t   &chi2rz  ,
+                    bendChi2_t &bendChi2,
+                    hit_t      &hit     ,
+                    trackMVA_t &trackMVA,
+                    extraMVA_t &extraMVA,
+                    valid_t    &valid   ){
+    unsigned int lo = 0;
+    unsigned int len = 0;
+    len=rinv_t    ::width; bit_copy(in, rinv    , lo); lo += len;
+    len=tkphi_t   ::width; bit_copy(in, tkphi   , lo); lo += len;
+    len=tanlam_t  ::width; bit_copy(in, tanlam  , lo); lo += len;
+    len=tkz0_t    ::width; bit_copy(in, tkz0    , lo); lo += len;
+    len=tkd0_t    ::width; bit_copy(in, tkd0    , lo); lo += len;
+    len=chi2rphi_t::width; bit_copy(in, chi2rphi, lo); lo += len;
+    len=chi2rz_t  ::width; bit_copy(in, chi2rz  , lo); lo += len;
+    len=bendChi2_t::width; bit_copy(in, bendChi2, lo); lo += len;
+    len=hit_t     ::width; bit_copy(in, hit     , lo); lo += len;
+    len=trackMVA_t::width; bit_copy(in, trackMVA, lo); lo += len;
+    len=extraMVA_t::width; bit_copy(in, extraMVA, lo); lo += len;
+    len=valid_t   ::width; bit_copy(in, valid   , lo); lo += len;
+}
+
+void pack_pf_track(ap_uint<64> &tk,
+                   pt_t     pf_pt   ,
+                   pt_t     pf_pterr,
+                   etaphi_t pf_eta  ,
+                   etaphi_t pf_phi  ,
+                   z0_t     pf_z0   ,
+                   bool     pf_TightQuality){
+    tk = (pf_TightQuality, pf_z0, pf_phi, pf_eta, pf_pterr, pf_pt);    
+}
+
+void unpack_pf_track(ap_uint<64> in,
+                   pt_t     &pf_pt   ,
+                   pt_t     &pf_pterr,
+                   etaphi_t &pf_eta  ,
+                   etaphi_t &pf_phi  ,
+                   z0_t     &pf_z0   ,
+                   bool     &pf_TightQuality){
+    unsigned int lo = 0;
+    unsigned int len = 0;
+    len=pt_t    ::width; bit_copy(in, pf_pt          , lo); lo += len;
+    len=pt_t    ::width; bit_copy(in, pf_pterr       , lo); lo += len;
+    len=etaphi_t::width; bit_copy(in, pf_eta         , lo); lo += len;
+    len=etaphi_t::width; bit_copy(in, pf_phi         , lo); lo += len;
+    len=z0_t    ::width; bit_copy(in, pf_z0          , lo); lo += len;
+    pf_TightQuality = in[lo];
+}
+
+template<class in_t, class out_t> 
+void bit_copy(in_t in, out_t &out, int offset){
+    for(int i  =out_t::width-1; i>=0; i--){
+        out[i] = in[i+offset];
+    }    
+}
+
+template<class pt_inv_T, class pt_T>
+void init_pt_inv_table(pt_T table_out[(1<<PT_INV_TAB_SIZE)]) {
+    // index is a uint from 0 to 111...11=2^PT_INV_TAB_SIZE-1 that encodes 0.000 to 0.4999999
+    // resulting value pt_T is a uint from 0 to 2^16-1
+    table_out[0] = (1<<PT_INV_MAX_BITS);
+    for (unsigned int i = 1; i < (1<<PT_INV_TAB_SIZE); i++) {
+        float invpt = float(i)/(1<<PT_INV_TAB_SIZE) * 0.5; // in 1/GeV
+        table_out[i] = PF_PT_SCALE / invpt;
+    }
+    return;
+}
+
+template<class pt_inv_T, class pt_T>
+void convert_pt(pt_inv_T inv, pt_T &pt){
+    //pt_inv_T is ap_fixed<> (signed)
+    //pt_T is ap_uint<> !
+
+    // Initialize the lookup tables
+#ifdef __HLS_SYN__
+    bool initialized = false;
+    pt_t inv_table[(1<<PT_INV_TAB_SIZE)];
+#else 
+    static bool initialized = false;
+    static pt_t inv_table[(1<<PT_INV_TAB_SIZE)];
+#endif
+    if (!initialized) {
+        init_pt_inv_table<pt_inv_T,pt_T>(inv_table);
+        initialized = true;
+    }
+
+    if(inv<0) inv = -inv;
+    urinv_t uinv = inv;
+
+    // cutoffs at high and low pt
+    if(uinv >= urinv_t(0.5)){
+        pt = 2. * PF_PT_SCALE;
+        return;
+    } else if (uinv <= urinv_t(1./(1<<PT_INV_MAX_BITS))){
+        pt=(1<<PT_INV_MAX_BITS) * PF_PT_SCALE;
+        return;
+    }
+
+    ap_uint<PT_INV_TAB_SIZE> index;
+    const int offset = 1; // ignore the first bit since 0b0.01111.. = 0.499.. is largest value
+    #pragma unroll
+    for(int i=0; i<PT_INV_TAB_SIZE; i++){
+        index[PT_INV_TAB_SIZE-1-i] = uinv[urinv_t::width-1-i-offset]; //msb down to lowest
+    }
+
+    pt = inv_table[index];
+}
+
+template<class eta_T>
+void init_eta_table(eta_T table_out[(1<<ETA_TAB_SIZE)]) {
+    // index is a uint from 0 to 111...11=2^ETA_TAB_SIZE-1 that encodes 0.000 to 8
+    // resulting value eta_T is a uint
+
+    for (unsigned int i = 0; i < (1<<ETA_TAB_SIZE); i++) {
+        // eta =  -ln(tan((pi/2 - arctan(TANLAM))/2))
+        float tanlam = float(i)/(1<<ETA_TAB_SIZE) * 8.;
+        float eta = -log(tan((M_PI/2 - atan(tanlam))/2));
+        table_out[i] = eta * PF_ETAPHI_SCALE;
+        // phi in -511,512 can only hold eta up to 2.23. else saturate for now
+        if (eta * PF_ETAPHI_SCALE > (1<<(eta_T::width-1))-1) table_out[i] = (1<<(eta_T::width-1))-1;
+    }
+    return;
+}
+
+template<class tanlam_T, class eta_T>
+void convert_eta(tanlam_T tanlam, eta_T &eta){
+    // tanlam_T is ap_fixed<16,3>
+    // eta_T is ap_int<10>
+
+    // Initialize the lookup tables
+#ifdef __HLS_SYN__
+    bool initialized = false;
+    etaphi_t eta_table[(1<<ETA_TAB_SIZE)];
+#else 
+    static bool initialized = false;
+    static etaphi_t eta_table[(1<<ETA_TAB_SIZE)];
+#endif
+    if (!initialized) {
+        init_eta_table<eta_T>(eta_table);
+        initialized = true;
+    }
+    bool flip = false;
+    if(tanlam<0){
+        tanlam = -tanlam;
+        flip=true;
+    }
+    utanlam_t utanlam = tanlam;
+
+    ap_uint<ETA_TAB_SIZE> index;
+    #pragma unroll
+    for(int i=0; i<ETA_TAB_SIZE; i++){
+        index[ETA_TAB_SIZE-1-i] = utanlam[utanlam_t::width-1-i]; //msb down to lowest
+    }
+
+    eta = eta_table[index];
+    if(flip) eta = -eta;
+}

--- a/converter/firmware/wrapper.h
+++ b/converter/firmware/wrapper.h
@@ -5,9 +5,10 @@
 #include <cmath>
 #include "ap_int.h"
 #include "ap_fixed.h"
-
-/* #include "types.h" */
-/* #include "convert_pt.h" */
+#include "../../firmware/data.h"
+#include "../../l1tk_types.h"
+using namespace l1tk;
+//#include "../../DiscretePFInputs.h"
 
 #define PT_INV_TAB_SIZE 8
 #define PT_INV_MAX_BITS 8
@@ -15,67 +16,8 @@
 
 typedef ap_uint<96> input_t;
 typedef ap_uint<64> output_t;
-
 void pf_input_track_conv_hw(input_t in, output_t& out);
 
-
-
-enum TrackBitWidths { 
-//MSB
-    kValid              = 1,                                    // Valid bit
-
-    kMVAExtraSize       = 6,                                    // Space for two specialized MVA selections
-    kTrackMVASize       = 3,                                    // Width of track quality MVA
-    kHitPatternSize     = 7,                                    // Width of the hit pattern for stubs
-    kBendChi2Size       = 3,                                    // Width of the Bend-Chi2
-    kChi2RZSize         = 4,                                    // Width of Chi2 for r-z
-    kChi2RPhiSize       = 4,                                    // Width of Chi2 for r-phi
-    kTrackQualitySize   = kMVAExtraSize + kTrackMVASize \
-                        + kHitPatternSize + kBendChi2Size \
-                        + kChi2RZSize + kChi2RPhiSize,          // Width of track quality
-
-    kD0Size             = 13,                                   // Width of D0
-    kD0MagSize          = 5,                                    // Width of D0 magnitude (signed)
-    kZ0Size             = 12,                                   // Width of z-position
-    kZ0MagSize          = 5,                                    // Width of z-position magnitude (signed)
-    kEtaSize            = 16,                                   // Width of eta
-    kEtaMagSize         = 3+1, // ch twiki seems wrong (sign)   // Width of eta magnitude (signed)
-    kPhiSize            = 12,                                   // Width of phi
-    kPhiMagSize         = 0,                                    // Width of phi magnitude (signed)
-    kChargeSize         = 1,                                    // Charge of pT
-    kChargeMagSize      = 1,                                    // Width of charge magnitude (signed)
-    kPtSize             = 14,                                   // Width of pT
-    kPtMagSize          = 0,                                    // Width of pT magnitude (unsigned)
-//LSB
-    kTrackParamsSize    = kD0Size + kZ0Size + kEtaSize \
-                        + kPhiSize + kChargeSize + kPtSize,     // Width of track parameters
-
-    kTrackWordSize      = kValid \
-                        + kTrackQualitySize \
-                        + kTrackParamsSize,                     // Width of the Track Finding Word in bits
-};
-// spare
-typedef ap_uint<kValid>                                             valid_t;        // valid bit
-
-// track quality types
-typedef ap_uint<kTrackQualitySize>                                  trackQuality_t; // All track quality bits
-typedef ap_uint<kMVAExtraSize>                                      extraMVA_t;      // Specialized MVA selection
-typedef ap_uint<kTrackMVASize>                                      trackMVA_t;     // Track quality MVA
-typedef ap_uint<kHitPatternSize>                                    hit_t;          // Hit mask bits
-typedef ap_uint<kBendChi2Size>                                      bendChi2_t;     // Bend-Chi2
-typedef ap_uint<kChi2RZSize>                                        chi2rz_t;       // Chi2 r-z
-typedef ap_uint<kChi2RPhiSize>                                      chi2rphi_t;     // Chi2 r-phi
-
-// track parameters types
-typedef ap_fixed<kD0Size, kD0MagSize, AP_RND_CONV, AP_SAT>          tkd0_t;           // D0
-typedef ap_fixed<kZ0Size, kZ0MagSize, AP_RND_CONV, AP_SAT>          tkz0_t;           // Track z
-typedef ap_fixed<kEtaSize, kEtaMagSize, AP_RND_CONV, AP_SAT>        tanlam_t;         // Track eta
-typedef ap_fixed<kPhiSize, kPhiMagSize, AP_RND_CONV, AP_SAT>        tkphi_t;          // Track phi
-typedef bool                                                        q_t;              // Charge of track PT
-typedef ap_ufixed<kPtSize, kPtMagSize, AP_RND_CONV, AP_SAT>         tkpt_t;           // Track PT
-typedef ap_fixed<kPtSize+kChargeSize,0, AP_RND_CONV, AP_SAT>        rinv_t;           // 1/RT
-typedef ap_ufixed<kPtSize,0, AP_RND_CONV, AP_SAT>                   urinv_t;           // 1/RT unsigned
-typedef ap_ufixed<kEtaSize-1, kEtaMagSize-1, AP_RND_CONV, AP_SAT>   utanlam_t;         // Track eta
 
 typedef ap_fixed<24,12, AP_RND_CONV, AP_SAT> bigfix_t; // helper type
 
@@ -83,11 +25,9 @@ typedef ap_fixed<24,12, AP_RND_CONV, AP_SAT> bigfix_t; // helper type
 #define PF_PT_SCALE (4.0)
 #define PF_ETAPHI_SCALE (4*180./3.1415)
 #define PF_Z0_SCALE (20)
-typedef ap_int<16> pt_t;
-typedef ap_int<10> etaphi_t;
-typedef ap_int<5>  vtx_t;
-typedef ap_uint<3> particleid_t;
-typedef ap_int<10> z0_t;
+
+
+
 
 void pack_L1T_track(ap_uint<kTrackWordSize> &tk,
                     rinv_t     rinv    ,
@@ -141,7 +81,7 @@ template<class pt_inv_T, class pt_T> void convert_pt(pt_inv_T inv, pt_T &pt);
 template<class eta_T> void init_eta_table(eta_T table_out[(1<<ETA_TAB_SIZE)]);
 template<class tanlam_T, class eta_T> void convert_eta(tanlam_T tanlam, eta_T &eta);
 
-inline float tanlam_to_eta(float tanlam){return -log(tan((3.1415/2 - atan(tanlam))/2));}
+inline float tanlam_to_eta(float tanlam){return -log(tan((M_PI/2 - atan(tanlam))/2));}
 
 
 #endif

--- a/converter/firmware/wrapper.h
+++ b/converter/firmware/wrapper.h
@@ -1,0 +1,147 @@
+#ifndef WRAPPER_H
+#define WRAPPER_H
+
+#include <iostream>
+#include <cmath>
+#include "ap_int.h"
+#include "ap_fixed.h"
+
+/* #include "types.h" */
+/* #include "convert_pt.h" */
+
+#define PT_INV_TAB_SIZE 8
+#define PT_INV_MAX_BITS 8
+#define ETA_TAB_SIZE 8
+
+typedef ap_uint<96> input_t;
+typedef ap_uint<64> output_t;
+
+void pf_input_track_conv_hw(input_t in, output_t& out);
+
+
+
+enum TrackBitWidths { 
+//MSB
+    kValid              = 1,                                    // Valid bit
+
+    kMVAExtraSize       = 6,                                    // Space for two specialized MVA selections
+    kTrackMVASize       = 3,                                    // Width of track quality MVA
+    kHitPatternSize     = 7,                                    // Width of the hit pattern for stubs
+    kBendChi2Size       = 3,                                    // Width of the Bend-Chi2
+    kChi2RZSize         = 4,                                    // Width of Chi2 for r-z
+    kChi2RPhiSize       = 4,                                    // Width of Chi2 for r-phi
+    kTrackQualitySize   = kMVAExtraSize + kTrackMVASize \
+                        + kHitPatternSize + kBendChi2Size \
+                        + kChi2RZSize + kChi2RPhiSize,          // Width of track quality
+
+    kD0Size             = 13,                                   // Width of D0
+    kD0MagSize          = 5,                                    // Width of D0 magnitude (signed)
+    kZ0Size             = 12,                                   // Width of z-position
+    kZ0MagSize          = 5,                                    // Width of z-position magnitude (signed)
+    kEtaSize            = 16,                                   // Width of eta
+    kEtaMagSize         = 3+1, // ch twiki seems wrong (sign)   // Width of eta magnitude (signed)
+    kPhiSize            = 12,                                   // Width of phi
+    kPhiMagSize         = 0,                                    // Width of phi magnitude (signed)
+    kChargeSize         = 1,                                    // Charge of pT
+    kChargeMagSize      = 1,                                    // Width of charge magnitude (signed)
+    kPtSize             = 14,                                   // Width of pT
+    kPtMagSize          = 0,                                    // Width of pT magnitude (unsigned)
+//LSB
+    kTrackParamsSize    = kD0Size + kZ0Size + kEtaSize \
+                        + kPhiSize + kChargeSize + kPtSize,     // Width of track parameters
+
+    kTrackWordSize      = kValid \
+                        + kTrackQualitySize \
+                        + kTrackParamsSize,                     // Width of the Track Finding Word in bits
+};
+// spare
+typedef ap_uint<kValid>                                             valid_t;        // valid bit
+
+// track quality types
+typedef ap_uint<kTrackQualitySize>                                  trackQuality_t; // All track quality bits
+typedef ap_uint<kMVAExtraSize>                                      extraMVA_t;      // Specialized MVA selection
+typedef ap_uint<kTrackMVASize>                                      trackMVA_t;     // Track quality MVA
+typedef ap_uint<kHitPatternSize>                                    hit_t;          // Hit mask bits
+typedef ap_uint<kBendChi2Size>                                      bendChi2_t;     // Bend-Chi2
+typedef ap_uint<kChi2RZSize>                                        chi2rz_t;       // Chi2 r-z
+typedef ap_uint<kChi2RPhiSize>                                      chi2rphi_t;     // Chi2 r-phi
+
+// track parameters types
+typedef ap_fixed<kD0Size, kD0MagSize, AP_RND_CONV, AP_SAT>          tkd0_t;           // D0
+typedef ap_fixed<kZ0Size, kZ0MagSize, AP_RND_CONV, AP_SAT>          tkz0_t;           // Track z
+typedef ap_fixed<kEtaSize, kEtaMagSize, AP_RND_CONV, AP_SAT>        tanlam_t;         // Track eta
+typedef ap_fixed<kPhiSize, kPhiMagSize, AP_RND_CONV, AP_SAT>        tkphi_t;          // Track phi
+typedef bool                                                        q_t;              // Charge of track PT
+typedef ap_ufixed<kPtSize, kPtMagSize, AP_RND_CONV, AP_SAT>         tkpt_t;           // Track PT
+typedef ap_fixed<kPtSize+kChargeSize,0, AP_RND_CONV, AP_SAT>        rinv_t;           // 1/RT
+typedef ap_ufixed<kPtSize,0, AP_RND_CONV, AP_SAT>                   urinv_t;           // 1/RT unsigned
+typedef ap_ufixed<kEtaSize-1, kEtaMagSize-1, AP_RND_CONV, AP_SAT>   utanlam_t;         // Track eta
+
+typedef ap_fixed<24,12, AP_RND_CONV, AP_SAT> bigfix_t; // helper type
+
+//#include "../../submodules/GlobalCorrelator_HLS/firmware/data.h"
+#define PF_PT_SCALE (4.0)
+#define PF_ETAPHI_SCALE (4*180./3.1415)
+#define PF_Z0_SCALE (20)
+typedef ap_int<16> pt_t;
+typedef ap_int<10> etaphi_t;
+typedef ap_int<5>  vtx_t;
+typedef ap_uint<3> particleid_t;
+typedef ap_int<10> z0_t;
+
+void pack_L1T_track(ap_uint<kTrackWordSize> &tk,
+                    rinv_t     rinv    ,
+                    tkphi_t    tkphi   ,
+                    tanlam_t   tanlam  ,
+                    tkz0_t     tkz0    ,
+                    tkd0_t     tkd0    ,
+                    chi2rphi_t chi2rphi,
+                    chi2rz_t   chi2rz  ,
+                    bendChi2_t bendChi2,
+                    hit_t      hit     ,
+                    trackMVA_t trackMVA,
+                    extraMVA_t extraMVA,
+                    valid_t    valid   ); 
+
+void unpack_L1T_track(ap_uint<kTrackWordSize> tk,
+                      rinv_t     &rinv    ,
+                      tkphi_t    &tkphi   ,
+                      tanlam_t   &tanlam  ,
+                      tkz0_t     &tkz0    ,
+                      tkd0_t     &tkd0    ,
+                      chi2rphi_t &chi2rphi,
+                      chi2rz_t   &chi2rz  ,
+                      bendChi2_t &bendChi2,
+                      hit_t      &hit     ,
+                      trackMVA_t &trackMVA,
+                      extraMVA_t &extraMVA,
+                      valid_t    &valid   );
+
+void pack_pf_track(ap_uint<64> &tk,
+                   pt_t     pf_pt   ,
+                   pt_t     pf_pterr,
+                   etaphi_t pf_eta  ,
+                   etaphi_t pf_phi  ,
+                   z0_t     pf_z0   ,
+                   bool     pf_TightQuality);
+
+void unpack_pf_track(ap_uint<64> tk,
+                     pt_t     &pf_pt   ,
+                     pt_t     &pf_pterr,
+                     etaphi_t &pf_eta  ,
+                     etaphi_t &pf_phi  ,
+                     z0_t     &pf_z0   ,
+                     bool     &pf_TightQuality);
+
+template<class in_t, class out_t> void bit_copy(in_t in, out_t &out, int offset=0);
+
+template<class pt_inv_T, class pt_T> void init_pt_inv_table(pt_T table_out[(1<<PT_INV_TAB_SIZE)]);
+template<class pt_inv_T, class pt_T> void convert_pt(pt_inv_T inv, pt_T &pt);
+
+template<class eta_T> void init_eta_table(eta_T table_out[(1<<ETA_TAB_SIZE)]);
+template<class tanlam_T, class eta_T> void convert_eta(tanlam_T tanlam, eta_T &eta);
+
+inline float tanlam_to_eta(float tanlam){return -log(tan((3.1415/2 - atan(tanlam))/2));}
+
+
+#endif

--- a/converter/firmware/wrapper.h
+++ b/converter/firmware/wrapper.h
@@ -18,15 +18,11 @@ typedef ap_uint<96> input_t;
 typedef ap_uint<64> output_t;
 void pf_input_track_conv_hw(input_t in, output_t& out);
 
-
 typedef ap_fixed<24,12, AP_RND_CONV, AP_SAT> bigfix_t; // helper type
 
-//#include "../../submodules/GlobalCorrelator_HLS/firmware/data.h"
 #define PF_PT_SCALE (4.0)
 #define PF_ETAPHI_SCALE (4*180./3.1415)
 #define PF_Z0_SCALE (20)
-
-
 
 
 void pack_L1T_track(ap_uint<kTrackWordSize> &tk,

--- a/converter/run.tcl
+++ b/converter/run.tcl
@@ -1,0 +1,27 @@
+# get the configuration
+#source config.tcl
+
+set mainAlgo pf_input_track_conv
+set topFunc ${mainAlgo}_hw
+
+# open the project, don't forget to reset
+open_project -reset "track-conv-test"
+set_top ${topFunc}
+add_files firmware/wrapper.cpp 
+add_files -tb test.cpp
+
+# reset the solution
+open_solution -reset "solution"
+set_part {xcvu9p-flgb2104-2-i}
+create_clock -period 3.125 -name default
+set_clock_uncertainty 1.5
+
+config_interface -trim_dangling_port
+# do stuff
+csim_design
+csynth_design
+cosim_design -trace_level all
+export_design -format ip_catalog -vendor "cern-cms" -version 0.1 -description "${mainAlgo}"
+
+# exit Vivado HLS
+exit

--- a/converter/test.cpp
+++ b/converter/test.cpp
@@ -1,0 +1,150 @@
+#include "ap_int.h"
+#include "ap_fixed.h"
+#include "firmware/wrapper.h"
+
+using std::cout;
+using std::endl;
+
+void test_tk_pack();
+void test_pf_pack();
+
+int main(){
+    // test_tk_pack();
+    // test_pf_pack();
+
+    unsigned int ntest=5;
+
+    // L1T tk parts for testing
+    rinv_t     rinv     = 0.5;
+    tkphi_t    tkphi    = 0.2;
+    tanlam_t   tanlam   = 1.;
+    tkz0_t     tkz0     = -2.25;
+    tkd0_t     tkd0     = 1.5;
+    chi2rphi_t chi2rphi = 1;
+    chi2rz_t   chi2rz   = 1;
+    bendChi2_t bendChi2 = 1;
+    hit_t      hit      = 0;
+    trackMVA_t trackMVA = 1;
+    extraMVA_t extraMVA = 1;
+    valid_t    valid    = 1;
+
+    // PF tk parts for testing
+    pt_t pf_pt = 20;
+    pt_t pf_pterr = 22;
+    etaphi_t pf_eta = -12;
+    etaphi_t pf_phi = 14;
+    z0_t pf_z0 = -3;
+    bool pf_TightQuality = true;
+
+    for(unsigned long itest=0; itest<ntest; itest++){
+        input_t in_tk;
+        output_t out_tk(0);
+        rinv = 1./(itest+2); // pt = 2,3,4,...
+        tanlam = 7 * float(itest)/ntest * (itest%2 ? 1:-1); // pt = 7*(0.1,-0.2,0.3,... )
+
+        pack_L1T_track(in_tk, rinv, tkphi, tanlam, tkz0, tkd0, chi2rphi, chi2rz, bendChi2, hit, trackMVA, extraMVA, valid);
+        pf_input_track_conv_hw(in_tk, out_tk);
+        unpack_pf_track(out_tk, pf_pt, pf_pterr, pf_eta, pf_phi, pf_z0, pf_TightQuality);
+
+        // std::cout << "pT: TB (" << rinv.to_double() << ") versus HW (" << pf_pt.to_double << ")" << std::endl;
+        // std::cout << "pT: TB (" << 1./rinv.to_double() << ") versus HW (" << pf_pt.to_double()/PF_PT_SCALE << ")" << std::endl;
+        // std::cout << "eta: TB (" << tanlam.to_double() << ") versus HW (" << pf_eta.to_double() << ")" << std::endl;
+        // std::cout << "eta: TB (" << tanlam_to_eta(tanlam.to_double()) << ") versus HW (" << pf_eta.to_double()/PF_ETAPHI_SCALE << ")" << std::endl;
+    }
+    return 0;
+}
+
+
+void test_tk_pack(){
+    unsigned int ntest=3;
+
+    // L1T tk parts for testing
+    rinv_t     rinv     = 0.5;
+    tkphi_t    tkphi    = 0.2;
+    tanlam_t   tanlam   = 1.;
+    tkz0_t     tkz0     = -2.25;
+    tkd0_t     tkd0     = 1.5;
+    chi2rphi_t chi2rphi = 1;
+    chi2rz_t   chi2rz   = 1;
+    bendChi2_t bendChi2 = 1;
+    hit_t      hit      = 0;
+    trackMVA_t trackMVA = 1;
+    extraMVA_t extraMVA = 1;
+    valid_t    valid    = 1;
+
+    for(unsigned long itest=0; itest<ntest; itest++){
+        ap_uint<96> tk;
+        rinv = 1./(itest+2); // pt = 2,3,4,...
+
+        std::cout << "Before packing:" << std::endl;
+        std::cout<<"rinv     "; for(int i=rinv_t    ::width-1; i>=0;i--){ std::cout << int( rinv    [i]);}std::cout << "  " << rinv    .to_double() << std::endl;
+        std::cout<<"tkphi    "; for(int i=tkphi_t   ::width-1; i>=0;i--){ std::cout << int( tkphi   [i]);}std::cout << "  " << tkphi   .to_double() << std::endl;
+        std::cout<<"tanlam   "; for(int i=tanlam_t  ::width-1; i>=0;i--){ std::cout << int( tanlam  [i]);}std::cout << "  " << tanlam  .to_double() << std::endl;
+        std::cout<<"tkz0     "; for(int i=tkz0_t    ::width-1; i>=0;i--){ std::cout << int( tkz0    [i]);}std::cout << "  " << tkz0    .to_double() << std::endl;
+        std::cout<<"tkd0     "; for(int i=tkd0_t    ::width-1; i>=0;i--){ std::cout << int( tkd0    [i]);}std::cout << "  " << tkd0    .to_double() << std::endl;
+        std::cout<<"chi2rphi "; for(int i=chi2rphi_t::width-1; i>=0;i--){ std::cout << int( chi2rphi[i]);}std::cout << "  " << chi2rphi.to_double() << std::endl;
+        std::cout<<"chi2rz   "; for(int i=chi2rz_t  ::width-1; i>=0;i--){ std::cout << int( chi2rz  [i]);}std::cout << "  " << chi2rz  .to_double() << std::endl;
+        std::cout<<"bendChi2 "; for(int i=bendChi2_t::width-1; i>=0;i--){ std::cout << int( bendChi2[i]);}std::cout << "  " << bendChi2.to_double() << std::endl;
+        std::cout<<"hit      "; for(int i=hit_t     ::width-1; i>=0;i--){ std::cout << int( hit     [i]);}std::cout << "  " << hit     .to_double() << std::endl;
+        std::cout<<"trackMVA "; for(int i=trackMVA_t::width-1; i>=0;i--){ std::cout << int( trackMVA[i]);}std::cout << "  " << trackMVA.to_double() << std::endl;
+        std::cout<<"extraMVA "; for(int i=extraMVA_t::width-1; i>=0;i--){ std::cout << int( extraMVA[i]);}std::cout << "  " << extraMVA.to_double() << std::endl;
+        std::cout<<"valid    "; for(int i=valid_t   ::width-1; i>=0;i--){ std::cout << int( valid   [i]);}std::cout << "  " << valid   .to_double() << std::endl;
+
+        pack_L1T_track(tk, rinv, tkphi, tanlam, tkz0, tkd0, chi2rphi, chi2rz, bendChi2, hit, trackMVA, extraMVA, valid);
+        unpack_L1T_track(tk, rinv, tkphi, tanlam, tkz0, tkd0, chi2rphi, chi2rz, bendChi2, hit, trackMVA, extraMVA, valid);
+
+        std::cout << "After packing:" << std::endl;
+        std::cout<<"rinv     "; for(int i=rinv_t    ::width-1; i>=0;i--){ std::cout << int( rinv    [i]);}std::cout << "  " << rinv    .to_double() << std::endl;
+        std::cout<<"tkphi    "; for(int i=tkphi_t   ::width-1; i>=0;i--){ std::cout << int( tkphi   [i]);}std::cout << "  " << tkphi   .to_double() << std::endl;
+        std::cout<<"tanlam   "; for(int i=tanlam_t  ::width-1; i>=0;i--){ std::cout << int( tanlam  [i]);}std::cout << "  " << tanlam  .to_double() << std::endl;
+        std::cout<<"tkz0     "; for(int i=tkz0_t    ::width-1; i>=0;i--){ std::cout << int( tkz0    [i]);}std::cout << "  " << tkz0    .to_double() << std::endl;
+        std::cout<<"tkd0     "; for(int i=tkd0_t    ::width-1; i>=0;i--){ std::cout << int( tkd0    [i]);}std::cout << "  " << tkd0    .to_double() << std::endl;
+        std::cout<<"chi2rphi "; for(int i=chi2rphi_t::width-1; i>=0;i--){ std::cout << int( chi2rphi[i]);}std::cout << "  " << chi2rphi.to_double() << std::endl;
+        std::cout<<"chi2rz   "; for(int i=chi2rz_t  ::width-1; i>=0;i--){ std::cout << int( chi2rz  [i]);}std::cout << "  " << chi2rz  .to_double() << std::endl;
+        std::cout<<"bendChi2 "; for(int i=bendChi2_t::width-1; i>=0;i--){ std::cout << int( bendChi2[i]);}std::cout << "  " << bendChi2.to_double() << std::endl;
+        std::cout<<"hit      "; for(int i=hit_t     ::width-1; i>=0;i--){ std::cout << int( hit     [i]);}std::cout << "  " << hit     .to_double() << std::endl;
+        std::cout<<"trackMVA "; for(int i=trackMVA_t::width-1; i>=0;i--){ std::cout << int( trackMVA[i]);}std::cout << "  " << trackMVA.to_double() << std::endl;
+        std::cout<<"extraMVA "; for(int i=extraMVA_t::width-1; i>=0;i--){ std::cout << int( extraMVA[i]);}std::cout << "  " << extraMVA.to_double() << std::endl;
+        std::cout<<"valid    "; for(int i=valid_t   ::width-1; i>=0;i--){ std::cout << int( valid   [i]);}std::cout << "  " << valid   .to_double() << std::endl;
+        std::cout<<std::endl;
+
+    }
+}
+void test_pf_pack(){
+    unsigned int ntest=3;
+
+    // PF parts for testing
+    pt_t pf_pt = 20;
+    pt_t pf_pterr = 22;
+    etaphi_t pf_eta = -12;
+    etaphi_t pf_phi = 14;
+    z0_t pf_z0 = -3;
+    bool pf_TightQuality = true;
+
+    for(unsigned long itest=0; itest<ntest; itest++){
+        pf_pt = 2+itest;
+        ap_uint<64> tk;
+
+        std::cout << "Before packing:" << std::endl;
+        std::cout<<"pf_pt    "; for(int i=pt_t    ::width-1; i>=0;i--){ std::cout << int(pf_pt   [i]);}std::cout << "  " << pf_pt   .to_double() << std::endl;
+        std::cout<<"pf_pterr "; for(int i=pt_t    ::width-1; i>=0;i--){ std::cout << int(pf_pterr[i]);}std::cout << "  " << pf_pterr.to_double() << std::endl;
+        std::cout<<"pf_eta   "; for(int i=etaphi_t::width-1; i>=0;i--){ std::cout << int(pf_eta  [i]);}std::cout << "  " << pf_eta  .to_double() << std::endl;
+        std::cout<<"pf_phi   "; for(int i=etaphi_t::width-1; i>=0;i--){ std::cout << int(pf_phi  [i]);}std::cout << "  " << pf_phi  .to_double() << std::endl;
+        std::cout<<"pf_z0    "; for(int i=z0_t    ::width-1; i>=0;i--){ std::cout << int(pf_z0   [i]);}std::cout << "  " << pf_z0   .to_double() << std::endl; 
+        std::cout<<"pf_TightQuality    " << pf_TightQuality << std::endl;
+        std::cout<<"tk       "; for(int i=ap_uint<64>::width-1; i>=0;i--){ std::cout << int(tk   [i]);}std::cout << std::endl;
+
+        pack_pf_track(tk, pf_pt, pf_pterr, pf_eta, pf_phi, pf_z0, pf_TightQuality);
+        unpack_pf_track(tk, pf_pt, pf_pterr, pf_eta, pf_phi, pf_z0, pf_TightQuality);
+
+        std::cout << "After packing:" << std::endl;
+        std::cout<<"pf_pt    "; for(int i=pt_t    ::width-1; i>=0;i--){ std::cout << int(pf_pt   [i]);}std::cout << "  " << pf_pt   .to_double() << std::endl;
+        std::cout<<"pf_pterr "; for(int i=pt_t    ::width-1; i>=0;i--){ std::cout << int(pf_pterr[i]);}std::cout << "  " << pf_pterr.to_double() << std::endl;
+        std::cout<<"pf_eta   "; for(int i=etaphi_t::width-1; i>=0;i--){ std::cout << int(pf_eta  [i]);}std::cout << "  " << pf_eta  .to_double() << std::endl;
+        std::cout<<"pf_phi   "; for(int i=etaphi_t::width-1; i>=0;i--){ std::cout << int(pf_phi  [i]);}std::cout << "  " << pf_phi  .to_double() << std::endl;
+        std::cout<<"pf_z0    "; for(int i=z0_t    ::width-1; i>=0;i--){ std::cout << int(pf_z0   [i]);}std::cout << "  " << pf_z0   .to_double() << std::endl; 
+        std::cout<<"pf_TightQuality    " << pf_TightQuality << std::endl;
+        std::cout<<"tk       "; for(int i=ap_uint<64>::width-1; i>=0;i--){ std::cout << int(tk   [i]);}std::cout << std::endl;
+        std::cout<<std::endl;
+    }
+}

--- a/l1tk_types.h
+++ b/l1tk_types.h
@@ -1,3 +1,5 @@
+#ifndef LONETRACK_TYPES_H
+#define LONETRACK_TYPES_H
 // From https://gitlab.cern.ch/GTT/common/-/blob/master/DataFormats/interface/Track.h
 // https://twiki.cern.ch/twiki/bin/viewauth/CMS/HybridDataFormat#Fitted_Tracks_written_by_KalmanF
 
@@ -64,3 +66,4 @@ namespace l1tk {
     const double kRmin = (2.*100.0*kSynchrotron); //2 is min pt
     const float rzphiChi2Bins[16] = {0, 0.25, 0.5, 1, 2, 3, 5, 7, 10, 20, 40, 100, 200, 500, 1000, 3000};
 }
+#endif

--- a/l1tk_types.h
+++ b/l1tk_types.h
@@ -1,0 +1,64 @@
+// From https://gitlab.cern.ch/GTT/common/-/blob/master/DataFormats/interface/Track.h
+// https://twiki.cern.ch/twiki/bin/viewauth/CMS/HybridDataFormat#Fitted_Tracks_written_by_KalmanF
+
+namespace l1tk {
+    enum TrackBitWidths { 
+        //MSB
+        kValid              = 1,                                    // Valid bit
+
+        kMVAExtraSize       = 6,                                    // Space for two specialized MVA selections
+        kTrackMVASize       = 3,                                    // Width of track quality MVA
+        kHitPatternSize     = 7,                                    // Width of the hit pattern for stubs
+        kBendChi2Size       = 3,                                    // Width of the Bend-Chi2
+        kChi2RZSize         = 4,                                    // Width of Chi2 for r-z
+        kChi2RPhiSize       = 4,                                    // Width of Chi2 for r-phi
+        kTrackQualitySize   = kMVAExtraSize + kTrackMVASize \
+        + kHitPatternSize + kBendChi2Size \
+        + kChi2RZSize + kChi2RPhiSize,          // Width of track quality
+
+        kD0Size             = 13,                                   // Width of D0
+        kD0MagSize          = 5,                                    // Width of D0 magnitude (signed)
+        kZ0Size             = 12,                                   // Width of z-position
+        kZ0MagSize          = 5,                                    // Width of z-position magnitude (signed)
+        kEtaSize            = 16,                                   // Width of eta
+        kEtaMagSize         = 3,                                    // Width of eta magnitude (signed)
+        kPhiSize            = 12,                                   // Width of phi
+        kPhiMagSize         = 0,                                    // Width of phi magnitude (signed)
+        kChargeSize         = 1,                                    // Charge of pT
+        kChargeMagSize      = 1,                                    // Width of charge magnitude (signed)
+        kPtSize             = 14,                                   // Width of pT
+        kPtMagSize          = 0,                                    // Width of pT magnitude (unsigned)
+        //LSB
+        kTrackParamsSize    = kD0Size + kZ0Size + kEtaSize \
+        + kPhiSize + kChargeSize + kPtSize,     // Width of track parameters
+
+        kTrackWordSize      = kValid \
+        + kTrackQualitySize \
+        + kTrackParamsSize,                     // Width of the Track Finding Word in bits
+    };
+    // spare
+    typedef ap_uint<kValid>                                             valid_t;        // valid bit
+
+    // track quality types
+    typedef ap_uint<kTrackQualitySize>                                  trackQuality_t; // All track quality bits
+    typedef ap_uint<kMVAExtraSize>                                      extraMVA_t;      // Specialized MVA selection
+    typedef ap_uint<kTrackMVASize>                                      trackMVA_t;     // Track quality MVA
+    typedef ap_uint<kHitPatternSize>                                    hit_t;          // Hit mask bits
+    typedef ap_uint<kBendChi2Size>                                      bendChi2_t;     // Bend-Chi2
+    typedef ap_uint<kChi2RZSize>                                        chi2rz_t;       // Chi2 r-z
+    typedef ap_uint<kChi2RPhiSize>                                      chi2rphi_t;     // Chi2 r-phi
+
+    // track parameters types
+    typedef ap_fixed<kD0Size, kD0MagSize, AP_RND_CONV, AP_SAT>          tkd0_t;           // D0
+    typedef ap_fixed<kZ0Size, kZ0MagSize, AP_RND_CONV, AP_SAT>          tkz0_t;           // Track z
+    typedef ap_fixed<kEtaSize, kEtaMagSize, AP_RND_CONV, AP_SAT>        tanlam_t;         // Track eta
+    typedef ap_fixed<kPhiSize, kPhiMagSize, AP_RND_CONV, AP_SAT>        tkphi_t;          // Track phi
+    typedef bool                                                        q_t;              // Charge of track PT
+    typedef ap_ufixed<kPtSize, kPtMagSize, AP_RND_CONV, AP_SAT>         tkpt_t;           // Track PT
+    typedef ap_fixed<kPtSize+kChargeSize,0, AP_RND_CONV, AP_SAT>        rinv_t;           // 1/RT
+
+    const double kSynchrotron = (1.0/(0.3*3.8));
+    const double kRmax = (128.*100.0*kSynchrotron); //128 is max pt
+    const double kRmin = (2.*100.0*kSynchrotron); //2 is min pt
+    const float rzphiChi2Bins[16] = {0, 0.25, 0.5, 1, 2, 3, 5, 7, 10, 20, 40, 100, 200, 500, 1000, 3000};
+}

--- a/l1tk_types.h
+++ b/l1tk_types.h
@@ -21,7 +21,7 @@ namespace l1tk {
         kZ0Size             = 12,                                   // Width of z-position
         kZ0MagSize          = 5,                                    // Width of z-position magnitude (signed)
         kEtaSize            = 16,                                   // Width of eta
-        kEtaMagSize         = 3,                                    // Width of eta magnitude (signed)
+        kEtaMagSize         = 3+1, // ch twiki seems wrong (sign)   // Width of eta magnitude (signed)
         kPhiSize            = 12,                                   // Width of phi
         kPhiMagSize         = 0,                                    // Width of phi magnitude (signed)
         kChargeSize         = 1,                                    // Charge of pT
@@ -29,7 +29,7 @@ namespace l1tk {
         kPtSize             = 14,                                   // Width of pT
         kPtMagSize          = 0,                                    // Width of pT magnitude (unsigned)
         //LSB
-        kTrackParamsSize    = kD0Size + kZ0Size + kEtaSize \
+        kTrackParamsSize    = kD0Size + kZ0Size + kEtaSize              \
         + kPhiSize + kChargeSize + kPtSize,     // Width of track parameters
 
         kTrackWordSize      = kValid \
@@ -56,6 +56,8 @@ namespace l1tk {
     typedef bool                                                        q_t;              // Charge of track PT
     typedef ap_ufixed<kPtSize, kPtMagSize, AP_RND_CONV, AP_SAT>         tkpt_t;           // Track PT
     typedef ap_fixed<kPtSize+kChargeSize,0, AP_RND_CONV, AP_SAT>        rinv_t;           // 1/RT
+    typedef ap_ufixed<kPtSize,0, AP_RND_CONV, AP_SAT>                   urinv_t;           // 1/RT unsigned
+    typedef ap_ufixed<kEtaSize-1, kEtaMagSize-1, AP_RND_CONV, AP_SAT>   utanlam_t;         // Track eta
 
     const double kSynchrotron = (1.0/(0.3*3.8));
     const double kRmax = (128.*100.0*kSynchrotron); //128 is max pt

--- a/make_tmux_inputs.tcl
+++ b/make_tmux_inputs.tcl
@@ -7,6 +7,7 @@ set_top ${l1pfTopFunc}
 #set_top pfalgo3_full
 add_files firmware/simple_fullpfalgo.cpp -cflags "-DTESTMP7 -DHLS_pipeline_II=2"
 add_files puppi/firmware/simple_puppi.cpp -cflags "-DTESTMP7 -DHLS_pipeline_II=2"
+add_files converter/firmware/wrapper.cpp -cflags "-DTESTMP7 -DHLS_pipeline_II=2"
 add_files -tb tmux_input_create_test.cpp  -cflags "-DTESTMP7 -DHLS_pipeline_II=2 -DMP7_TOP_FUNC=${l1pfTopFunc} -DMP7_REF_FUNC=${l1pfRefFunc} -DMP7_VALIDATE=${l1pfValidate}"
 add_files -tb simple_fullpfalgo_ref.cpp -cflags "-DTESTMP7"
 add_files -tb utils/pattern_serializer.cpp -cflags "-DTESTMP7"

--- a/tmux_create_test.h
+++ b/tmux_create_test.h
@@ -1,4 +1,5 @@
 #include <cstdio>
+#include <fstream>
 #include <iomanip>
 #include "firmware/simple_fullpfalgo.h"
 #include "vertexing/firmware/simple_vtx.h"

--- a/tmux_create_test.h
+++ b/tmux_create_test.h
@@ -201,9 +201,9 @@ inline void mp7_pack_full(l1tpf_int::Muon mu_in[N], MP7DataWord data[]) {
 void mp7wrapped_pack_in_full(l1tpf_int::CaloCluster emcalo[NEMCALO], l1tpf_int::CaloCluster hadcalo[NCALO], l1tpf_int::PropagatedTrack track[NTRACK], l1tpf_int::Muon mu[NMU], MP7DataWord data[MP7_NCHANN]) {
     // pack inputs
     assert(NWORDS_EMCALO*NEMCALO + NWORDS_TRACK*NTRACK + NWORDS_CALO*NCALO + NWORDS_MU*NMU <= MP7_NCHANN);
-    #define EMOFFS NWORDS_TRACK*NTRACK
-    #define HADOFFS NWORDS_EMCALO*NEMCALO+EMOFFS
-    #define MUOFFS NWORDS_CALO*NCALO+HADOFFS
+    constexpr unsigned int EMOFFS = NWORDS_TRACK*NTRACK;
+    constexpr unsigned int HADOFFS =  NWORDS_EMCALO*NEMCALO+EMOFFS;
+    constexpr unsigned int MUOFFS  = NWORDS_CALO*NCALO+HADOFFS;
 
     mp7_pack_full<NTRACK,0>(track, data);
     mp7_pack_full_em<NEMCALO,EMOFFS>(emcalo, data);
@@ -214,9 +214,10 @@ void mp7wrapped_pack_in_full(l1tpf_int::CaloCluster emcalo[NEMCALO], l1tpf_int::
 void mp7wrapped_pack_in_reorder(EmCaloObj emcalo[NEMCALO], HadCaloObj hadcalo[NCALO], TkObj track[NTRACK], MuObj mu[NMU], MP7DataWord data[MP7_NCHANN]) {
     // pack inputs
     assert(2*NEMCALO + 2*NTRACK + 2*NCALO + 2*NMU <= MP7_NCHANN);
-    #define EMOFFS 2*NTRACK
-    #define HADOFFS 2*NEMCALO+EMOFFS
-    #define MUOFFS 2*NCALO+HADOFFS
+    constexpr unsigned int EMOFFS = 2*NTRACK;
+    constexpr unsigned int HADOFFS = 2*NEMCALO+EMOFFS;
+    constexpr unsigned int MUOFFS  = 2*NCALO+HADOFFS;
+
     mp7_pack<NTRACK,0>(track, data);
     mp7_pack<NEMCALO,EMOFFS>(emcalo, data);
     mp7_pack<NCALO,HADOFFS>(hadcalo, data);

--- a/tmux_create_test.h
+++ b/tmux_create_test.h
@@ -11,6 +11,9 @@
 #include "utils/test_utils.h"
 #include "firmware/mp7pf_encoding.h"
 
+#include "l1tk_types.h"
+using namespace l1tk;
+
 #include <math.h>
 
 #define NTEST 6
@@ -76,67 +79,67 @@ inline void mp7_pack_full_had(l1tpf_int::CaloCluster hadcalo_in[N], MP7DataWord 
     }
 }
 
-//from https://gitlab.cern.ch/GTT/common/-/blob/master/DataFormats/interface/Track.h
-//https://twiki.cern.ch/twiki/bin/viewauth/CMS/HybridDataFormat#Fitted_Tracks_written_by_KalmanF
-enum TrackBitWidths { 
-//MSB
-    kValid              = 1,                                    // Valid bit
+/* //from https://gitlab.cern.ch/GTT/common/-/blob/master/DataFormats/interface/Track.h */
+/* //https://twiki.cern.ch/twiki/bin/viewauth/CMS/HybridDataFormat#Fitted_Tracks_written_by_KalmanF */
+/* enum TrackBitWidths {  */
+/* //MSB */
+/*     kValid              = 1,                                    // Valid bit */
 
-    kMVAExtraSize       = 6,                                    // Space for two specialized MVA selections
-    kTrackMVASize       = 3,                                    // Width of track quality MVA
-    kHitPatternSize     = 7,                                    // Width of the hit pattern for stubs
-    kBendChi2Size       = 3,                                    // Width of the Bend-Chi2
-    kChi2RZSize         = 4,                                    // Width of Chi2 for r-z
-    kChi2RPhiSize       = 4,                                    // Width of Chi2 for r-phi
-    kTrackQualitySize   = kMVAExtraSize + kTrackMVASize \
-                        + kHitPatternSize + kBendChi2Size \
-                        + kChi2RZSize + kChi2RPhiSize,          // Width of track quality
+/*     kMVAExtraSize       = 6,                                    // Space for two specialized MVA selections */
+/*     kTrackMVASize       = 3,                                    // Width of track quality MVA */
+/*     kHitPatternSize     = 7,                                    // Width of the hit pattern for stubs */
+/*     kBendChi2Size       = 3,                                    // Width of the Bend-Chi2 */
+/*     kChi2RZSize         = 4,                                    // Width of Chi2 for r-z */
+/*     kChi2RPhiSize       = 4,                                    // Width of Chi2 for r-phi */
+/*     kTrackQualitySize   = kMVAExtraSize + kTrackMVASize \ */
+/*                         + kHitPatternSize + kBendChi2Size \ */
+/*                         + kChi2RZSize + kChi2RPhiSize,          // Width of track quality */
 
-    kD0Size             = 13,                                   // Width of D0
-    kD0MagSize          = 5,                                    // Width of D0 magnitude (signed)
-    kZ0Size             = 12,                                   // Width of z-position
-    kZ0MagSize          = 5,                                    // Width of z-position magnitude (signed)
-    kEtaSize            = 16,                                   // Width of eta
-    kEtaMagSize         = 3,                                    // Width of eta magnitude (signed)
-    kPhiSize            = 12,                                   // Width of phi
-    kPhiMagSize         = 0,                                    // Width of phi magnitude (signed)
-    kChargeSize         = 1,                                    // Charge of pT
-    kChargeMagSize      = 1,                                    // Width of charge magnitude (signed)
-    kPtSize             = 14,                                   // Width of pT
-    kPtMagSize          = 0,                                    // Width of pT magnitude (unsigned)
-//LSB
-    kTrackParamsSize    = kD0Size + kZ0Size + kEtaSize \
-                        + kPhiSize + kChargeSize + kPtSize,     // Width of track parameters
+/*     kD0Size             = 13,                                   // Width of D0 */
+/*     kD0MagSize          = 5,                                    // Width of D0 magnitude (signed) */
+/*     kZ0Size             = 12,                                   // Width of z-position */
+/*     kZ0MagSize          = 5,                                    // Width of z-position magnitude (signed) */
+/*     kEtaSize            = 16,                                   // Width of eta */
+/*     kEtaMagSize         = 3,                                    // Width of eta magnitude (signed) */
+/*     kPhiSize            = 12,                                   // Width of phi */
+/*     kPhiMagSize         = 0,                                    // Width of phi magnitude (signed) */
+/*     kChargeSize         = 1,                                    // Charge of pT */
+/*     kChargeMagSize      = 1,                                    // Width of charge magnitude (signed) */
+/*     kPtSize             = 14,                                   // Width of pT */
+/*     kPtMagSize          = 0,                                    // Width of pT magnitude (unsigned) */
+/* //LSB */
+/*     kTrackParamsSize    = kD0Size + kZ0Size + kEtaSize \ */
+/*                         + kPhiSize + kChargeSize + kPtSize,     // Width of track parameters */
 
-    kTrackWordSize      = kValid \
-                        + kTrackQualitySize \
-                        + kTrackParamsSize,                     // Width of the Track Finding Word in bits
-};
-// spare
-typedef ap_uint<kValid>                                             valid_t;        // valid bit
+/*     kTrackWordSize      = kValid \ */
+/*                         + kTrackQualitySize \ */
+/*                         + kTrackParamsSize,                     // Width of the Track Finding Word in bits */
+/* }; */
+/* // spare */
+/* typedef ap_uint<kValid>                                             valid_t;        // valid bit */
 
-// track quality types
-typedef ap_uint<kTrackQualitySize>                                  trackQuality_t; // All track quality bits
-typedef ap_uint<kMVAExtraSize>                                      extraMVA_t;      // Specialized MVA selection
-typedef ap_uint<kTrackMVASize>                                      trackMVA_t;     // Track quality MVA
-typedef ap_uint<kHitPatternSize>                                    hit_t;          // Hit mask bits
-typedef ap_uint<kBendChi2Size>                                      bendChi2_t;     // Bend-Chi2
-typedef ap_uint<kChi2RZSize>                                        chi2rz_t;       // Chi2 r-z
-typedef ap_uint<kChi2RPhiSize>                                      chi2rphi_t;     // Chi2 r-phi
+/* // track quality types */
+/* typedef ap_uint<kTrackQualitySize>                                  trackQuality_t; // All track quality bits */
+/* typedef ap_uint<kMVAExtraSize>                                      extraMVA_t;      // Specialized MVA selection */
+/* typedef ap_uint<kTrackMVASize>                                      trackMVA_t;     // Track quality MVA */
+/* typedef ap_uint<kHitPatternSize>                                    hit_t;          // Hit mask bits */
+/* typedef ap_uint<kBendChi2Size>                                      bendChi2_t;     // Bend-Chi2 */
+/* typedef ap_uint<kChi2RZSize>                                        chi2rz_t;       // Chi2 r-z */
+/* typedef ap_uint<kChi2RPhiSize>                                      chi2rphi_t;     // Chi2 r-phi */
 
-// track parameters types
-typedef ap_fixed<kD0Size, kD0MagSize, AP_RND_CONV, AP_SAT>          tkd0_t;           // D0
-typedef ap_fixed<kZ0Size, kZ0MagSize, AP_RND_CONV, AP_SAT>          tkz0_t;           // Track z
-typedef ap_fixed<kEtaSize, kEtaMagSize, AP_RND_CONV, AP_SAT>        tanlam_t;         // Track eta
-typedef ap_fixed<kPhiSize, kPhiMagSize, AP_RND_CONV, AP_SAT>        tkphi_t;          // Track phi
-typedef bool                                                        q_t;              // Charge of track PT
-typedef ap_ufixed<kPtSize, kPtMagSize, AP_RND_CONV, AP_SAT>         tkpt_t;           // Track PT
-typedef ap_fixed<kPtSize+kChargeSize,0, AP_RND_CONV, AP_SAT>        rinv_t;           // 1/RT
+/* // track parameters types */
+/* typedef ap_fixed<kD0Size, kD0MagSize, AP_RND_CONV, AP_SAT>          tkd0_t;           // D0 */
+/* typedef ap_fixed<kZ0Size, kZ0MagSize, AP_RND_CONV, AP_SAT>          tkz0_t;           // Track z */
+/* typedef ap_fixed<kEtaSize, kEtaMagSize, AP_RND_CONV, AP_SAT>        tanlam_t;         // Track eta */
+/* typedef ap_fixed<kPhiSize, kPhiMagSize, AP_RND_CONV, AP_SAT>        tkphi_t;          // Track phi */
+/* typedef bool                                                        q_t;              // Charge of track PT */
+/* typedef ap_ufixed<kPtSize, kPtMagSize, AP_RND_CONV, AP_SAT>         tkpt_t;           // Track PT */
+/* typedef ap_fixed<kPtSize+kChargeSize,0, AP_RND_CONV, AP_SAT>        rinv_t;           // 1/RT */
 
-const double kSynchrotron = (1.0/(0.3*3.8));
-const double kRmax = (128.*100.0*kSynchrotron); //128 is max pt
-const double kRmin = (2.*100.0*kSynchrotron); //2 is min pt
-const float rzphiChi2Bins[16] = {0, 0.25, 0.5, 1, 2, 3, 5, 7, 10, 20, 40, 100, 200, 500, 1000, 3000};
+/* const double kSynchrotron = (1.0/(0.3*3.8)); */
+/* const double kRmax = (128.*100.0*kSynchrotron); //128 is max pt */
+/* const double kRmin = (2.*100.0*kSynchrotron); //2 is min pt */
+/* const float rzphiChi2Bins[16] = {0, 0.25, 0.5, 1, 2, 3, 5, 7, 10, 20, 40, 100, 200, 500, 1000, 3000}; */
 
 template<unsigned int N, unsigned int OFFS> 
 inline void mp7_pack_full(l1tpf_int::PropagatedTrack track_in[N], MP7DataWord data[]) {

--- a/tmux_create_test.h
+++ b/tmux_create_test.h
@@ -14,6 +14,9 @@
 #include "l1tk_types.h"
 using namespace l1tk;
 
+#include "converter/firmware/wrapper.h"
+
+
 #include <math.h>
 
 #define NTEST 6
@@ -49,6 +52,8 @@ using namespace l1tk;
 #define NWORDS_EMCALO 2
 #define NWORDS_MU 2
 
+#define CONVERT_INPUTS 0
+
 template<unsigned int N, unsigned int OFFS> 
 inline void mp7_pack_full_em(l1tpf_int::CaloCluster emcalo_in[N], MP7DataWord data[]) {
     EmCaloObj emcalo[N];
@@ -78,68 +83,6 @@ inline void mp7_pack_full_had(l1tpf_int::CaloCluster hadcalo_in[N], MP7DataWord 
         data[NWORDS_CALO*i+1+OFFS] = ( hadcalo[i].hwIsEM, hadcalo[i].hwPhi, hadcalo[i].hwEta );
     }
 }
-
-/* //from https://gitlab.cern.ch/GTT/common/-/blob/master/DataFormats/interface/Track.h */
-/* //https://twiki.cern.ch/twiki/bin/viewauth/CMS/HybridDataFormat#Fitted_Tracks_written_by_KalmanF */
-/* enum TrackBitWidths {  */
-/* //MSB */
-/*     kValid              = 1,                                    // Valid bit */
-
-/*     kMVAExtraSize       = 6,                                    // Space for two specialized MVA selections */
-/*     kTrackMVASize       = 3,                                    // Width of track quality MVA */
-/*     kHitPatternSize     = 7,                                    // Width of the hit pattern for stubs */
-/*     kBendChi2Size       = 3,                                    // Width of the Bend-Chi2 */
-/*     kChi2RZSize         = 4,                                    // Width of Chi2 for r-z */
-/*     kChi2RPhiSize       = 4,                                    // Width of Chi2 for r-phi */
-/*     kTrackQualitySize   = kMVAExtraSize + kTrackMVASize \ */
-/*                         + kHitPatternSize + kBendChi2Size \ */
-/*                         + kChi2RZSize + kChi2RPhiSize,          // Width of track quality */
-
-/*     kD0Size             = 13,                                   // Width of D0 */
-/*     kD0MagSize          = 5,                                    // Width of D0 magnitude (signed) */
-/*     kZ0Size             = 12,                                   // Width of z-position */
-/*     kZ0MagSize          = 5,                                    // Width of z-position magnitude (signed) */
-/*     kEtaSize            = 16,                                   // Width of eta */
-/*     kEtaMagSize         = 3,                                    // Width of eta magnitude (signed) */
-/*     kPhiSize            = 12,                                   // Width of phi */
-/*     kPhiMagSize         = 0,                                    // Width of phi magnitude (signed) */
-/*     kChargeSize         = 1,                                    // Charge of pT */
-/*     kChargeMagSize      = 1,                                    // Width of charge magnitude (signed) */
-/*     kPtSize             = 14,                                   // Width of pT */
-/*     kPtMagSize          = 0,                                    // Width of pT magnitude (unsigned) */
-/* //LSB */
-/*     kTrackParamsSize    = kD0Size + kZ0Size + kEtaSize \ */
-/*                         + kPhiSize + kChargeSize + kPtSize,     // Width of track parameters */
-
-/*     kTrackWordSize      = kValid \ */
-/*                         + kTrackQualitySize \ */
-/*                         + kTrackParamsSize,                     // Width of the Track Finding Word in bits */
-/* }; */
-/* // spare */
-/* typedef ap_uint<kValid>                                             valid_t;        // valid bit */
-
-/* // track quality types */
-/* typedef ap_uint<kTrackQualitySize>                                  trackQuality_t; // All track quality bits */
-/* typedef ap_uint<kMVAExtraSize>                                      extraMVA_t;      // Specialized MVA selection */
-/* typedef ap_uint<kTrackMVASize>                                      trackMVA_t;     // Track quality MVA */
-/* typedef ap_uint<kHitPatternSize>                                    hit_t;          // Hit mask bits */
-/* typedef ap_uint<kBendChi2Size>                                      bendChi2_t;     // Bend-Chi2 */
-/* typedef ap_uint<kChi2RZSize>                                        chi2rz_t;       // Chi2 r-z */
-/* typedef ap_uint<kChi2RPhiSize>                                      chi2rphi_t;     // Chi2 r-phi */
-
-/* // track parameters types */
-/* typedef ap_fixed<kD0Size, kD0MagSize, AP_RND_CONV, AP_SAT>          tkd0_t;           // D0 */
-/* typedef ap_fixed<kZ0Size, kZ0MagSize, AP_RND_CONV, AP_SAT>          tkz0_t;           // Track z */
-/* typedef ap_fixed<kEtaSize, kEtaMagSize, AP_RND_CONV, AP_SAT>        tanlam_t;         // Track eta */
-/* typedef ap_fixed<kPhiSize, kPhiMagSize, AP_RND_CONV, AP_SAT>        tkphi_t;          // Track phi */
-/* typedef bool                                                        q_t;              // Charge of track PT */
-/* typedef ap_ufixed<kPtSize, kPtMagSize, AP_RND_CONV, AP_SAT>         tkpt_t;           // Track PT */
-/* typedef ap_fixed<kPtSize+kChargeSize,0, AP_RND_CONV, AP_SAT>        rinv_t;           // 1/RT */
-
-/* const double kSynchrotron = (1.0/(0.3*3.8)); */
-/* const double kRmax = (128.*100.0*kSynchrotron); //128 is max pt */
-/* const double kRmin = (2.*100.0*kSynchrotron); //2 is min pt */
-/* const float rzphiChi2Bins[16] = {0, 0.25, 0.5, 1, 2, 3, 5, 7, 10, 20, 40, 100, 200, 500, 1000, 3000}; */
 
 template<unsigned int N, unsigned int OFFS> 
 inline void mp7_pack_full(l1tpf_int::PropagatedTrack track_in[N], MP7DataWord data[]) {
@@ -182,6 +125,16 @@ inline void mp7_pack_full(l1tpf_int::PropagatedTrack track_in[N], MP7DataWord da
             data[NWORDS_TRACK*i+2+OFFS] = 0;
             data[NWORDS_TRACK*i+1+OFFS] = 0;
             data[NWORDS_TRACK*i+0+OFFS] = 0;
+        }
+        if(CONVERT_INPUTS){
+            ap_uint<96> in = (data[NWORDS_TRACK*i+2+OFFS],
+                              data[NWORDS_TRACK*i+1+OFFS],
+                              data[NWORDS_TRACK*i+0+OFFS]);
+            ap_uint<64> out;
+            pf_input_track_conv_hw(in, out);
+            data[NWORDS_TRACK*i+2+OFFS] = 0;
+            data[NWORDS_TRACK*i+1+OFFS] = out(63,32);
+            data[NWORDS_TRACK*i+0+OFFS] = out(31, 0);
         }
     }
 }

--- a/tmux_input_create_test.cpp
+++ b/tmux_input_create_test.cpp
@@ -325,17 +325,19 @@ int main() {
         if (1 && link_off+(NLINKS_PER_REG+1) > NLINKS_APX_GEN0) link_off = 0;
     
     }
-    //std::cout<<std::endl;
+    std::ofstream outfile;
+    outfile.open("../../../../inputs.txt");
     for (int ib = 0; ib < listLength; ib++){
         // std::cout << ib << " ";
-        std::cout << "0x" << std::setfill('0') << std::setw(4) << std::hex << ib << "   " <<std::dec;
+        outfile << "0x" << std::setfill('0') << std::setw(4) << std::hex << ib << "   " <<std::dec;
         //for (int ia = 0; ia < NLINKS_APX_GEN0; ia++){
         for (int ia = NLINKS_APX_GEN0-1; ia >=0; ia--){
             //datawords[ia][ib] = "0x0000000000000000";
-            std::cout << datawords[ia][ib] << "    ";
+            outfile << datawords[ia][ib] << "    ";
         }
-        std::cout << std::endl;
+        outfile << std::endl;
     }
+    outfile.close();
 
     // std::cout<<"For all events: "<<std::endl;
     // std::cout<<"\ttrack  = "<<n_alltracks<<std::endl;

--- a/tmux_layer1_create_test.cpp
+++ b/tmux_layer1_create_test.cpp
@@ -300,19 +300,22 @@ int main() {
     
     }
 
+    std::ofstream outfile;
+    outfile.open("../../../../layer1.txt");
     int iclk = 0;
     for (int ia = 0; ia < NTEST; ia++){
         for (int io = 0; io < NREGIONS; io++){
-            std::cout << "0x" << std::setfill('0') << std::setw(4) << std::hex << iclk << "   " <<std::dec;
+            outfile << "0x" << std::setfill('0') << std::setw(4) << std::hex << iclk << "   " <<std::dec;
             //for (int ib = 0; ib < mp7DataLength+1; ib++){
             for (int ib = NLINKS_APX_GEN0-1; ib >= 0; ib--){
                 //std::cout << ia*NREGIONS+outputOrder[io] << "-" << ib << "    ";
-                std::cout << datawords[ia*NREGIONS+outputOrder[io]][ib] << "    ";
+                outfile << datawords[ia*NREGIONS+outputOrder[io]][ib] << "    ";
             }
-            std::cout << std::endl;
+            outfile << std::endl;
             iclk++;
         }
     }
+    outfile.close();
 
     return 0;
 }

--- a/tmux_output_create_test.cpp
+++ b/tmux_output_create_test.cpp
@@ -276,17 +276,20 @@ int main() {
     }
 
 
+    std::ofstream outfile;
+    outfile.open("../../../../output.txt");
     int iclk = 0;
     for (int ia = 0; ia < NTEST; ia++){
         for (int io = 0; io < TMUX_IN; io++){
-            std::cout << "0x" << std::setfill('0') << std::setw(4) << std::hex << iclk << "   " <<std::dec;
+            outfile << "0x" << std::setfill('0') << std::setw(4) << std::hex << iclk << "   " <<std::dec;
             for (int ib = 0; ib < mp7DataLength+1; ib++){
-                std::cout << datawords[ia*TMUX_IN+outputOrder[io]][ib] << "    ";
+                outfile << datawords[ia*TMUX_IN+outputOrder[io]][ib] << "    ";
             }
-            std::cout << std::endl;
+            outfile << std::endl;
             iclk++;
         }
     }
+    outfile.close();
 
     return 0;
 }


### PR DESCRIPTION
This PR adds the converter block to the main repo along with PF+PUPPI IPs. The standalone block lives in `converter/` along with a dedicated testbench and may also also be called in the emulator test scripts.  (I've made a first pass at incorporating the converter into the tmux input tests but we can discuss the details @drankincms .)

In addition, the L1Track types are factored out into a separate header so they can be used by both the input tests and conversion module.  Outputs from tmux tests are now also automatically written to streams (`inputs.txt`, `outputs.txt`, and `layer1.txt`) instead of `std::cout`.